### PR TITLE
Shorten the temp path name by always using /tmp. Linux allows a max o…

### DIFF
--- a/src/common/Util.js
+++ b/src/common/Util.js
@@ -29,31 +29,7 @@ class Util {
 	}
 
 	static getRootTempDirectory(config, rootDir) {
-		let tmpDir;
-		if (config.tempDirectory)
-			tmpDir = config.tempDirectory;
-		else if (config && config.__state && config.__state.tempDirectory)
-            tmpDir = config.__state.tempDirectory;
-		else
-			tmpDir = "tmp";
-
-		// Make absolute.
-		tmpDir = path.resolve(rootDir, tmpDir);
-
-		// Make sure the parent directory exists.
-		try {
-			fs.accessSync(tmpDir, fs.constants.R_OK | fs.constants.W_OK | fs.constants.F_OK);
-		}
-		catch (e) {
-			try {
-				fs.mkdirSync(tmpDir);
-			}
-			catch (e) {
-				throw "Failed to create \"" + tmpDir + ".\n" + e;
-			}
-		}
-
-		return tmpDir;
+		return "/tmp";  // Always use /tmp.
 	}
 
 	static getTempDirectory(config, rootDir) {
@@ -61,8 +37,7 @@ class Util {
 		let tmpDir = this.getRootTempDirectory(config, rootDir);
 
 		// Create a temporary child directory.
-		let basename = path.basename(config.scriptName || "tmp", ".js");
-		tmpDir = path.resolve(tmpDir, basename + this.createGUID());
+		tmpDir = path.resolve(tmpDir, this.createGUID());
 
 		try {
 			fs.mkdirSync(tmpDir);

--- a/src/validator/validator.js
+++ b/src/validator/validator.js
@@ -478,7 +478,7 @@ class Validator {
 	    config.__state = {};
 	    
 	    config.__state.rootDirectory = config.rootDirectory || this.rootDir;
-	    config.__state.tempDirectory = config.tempDirectory || this.tempDir;
+	    config.__state.tempDirectory = this.tempDir;
 	    config.__state.encoding = config.encoding || this.encoding;
 	    config.__state.validator = this;
 	    config.__state.sharedData = this.sharedData;


### PR DESCRIPTION
…f 108 characters for a socket name.