### PR TITLE
Feature/remove error abort count

### DIFF
--- a/src/api/BaseRuleAPI.js
+++ b/src/api/BaseRuleAPI.js
@@ -64,15 +64,21 @@ class BaseRuleAPI extends ErrorHandlerAPI {
     static appendConfigProperties(inProperties) {
 
         const properties = [
-            {
+            /*{
                 name: 'errorsToAbort',
                 label: 'How many errors before abort on this rule?',
+                type: 'integer',
+                tooltip: 'Stop execution when these many errors occur.'
+            },*/ //hide from the UI
+            {
+                name: 'droppedToAbort',
+                label: 'How many dropped items before aborting on this rule?',
                 type: 'integer',
                 tooltip: 'Stop execution when these many errors occur.'
             },
             {
                 name: 'warningsToAbort',
-                label: 'How many warnings before abort on this rule?',
+                label: 'How many warnings before aborting on this rule?',
                 type: 'integer',
                 tooltip: 'Stop execution when these many warnings occur.'
             }

--- a/src/client/app/components/run-details.js
+++ b/src/client/app/components/run-details.js
@@ -161,29 +161,58 @@ export default Ember.Component.extend({
 
 			const selected = row.classList.contains('selected');
 
-			deselectItems(selected, this);
+			deselectItems(this);
+
+			this.set('page',1);
 
 			if(!selected) {
 				row.classList.add('selected');
-
 				this.set('showErrors', rule);
-				this.set('page', 1);
 				this.set('ruleid', rule.config.id);
-
-
+			} else {
+				this.set('showErrors', null);
+				this.set('ruleid', null);
 			}
 
 			this.sendAction('updateFilters');
 
 		},
+		toggleErrorType(id, type) {
+			const row = document.getElementById(id);
+
+			const selected = row.classList.contains('selected');
+
+			deselectItems(this, 'errorTypes');
+
+			this.set('page', 1);
+
+			if(!selected) {
+				row.classList.add('selected');
+				this.set('type', type);
+			} else {
+				this.set('type', null);
+			}
+
+			this.sendAction('updateFilters');
+		},
 		resetType() {
-			deselectItems(true, this);
+			deselectItems(this);
+
+			this.set('page',1);
+			this.set('showErrors', null);
+			this.set('ruleid', null);
+			this.set('type', null);
 		}
 	}
 });
 
-function deselectItems(clearProperties, c) {
-	const rulesElem = document.getElementById('rulesTable');
+function deselectItems(c, id) {
+
+	if(!id) {
+		id = 'rulesTable';
+	}
+
+	const rulesElem = document.getElementById(id);
 
 	const items = rulesElem.childNodes;
 
@@ -193,11 +222,7 @@ function deselectItems(clearProperties, c) {
 			item.classList.remove('selected');
 	}
 
-	if(clearProperties) {
-		c.set('showErrors', null);
-		c.set('page',1);
-		c.set('ruleid', null);
-	}
+
 
 	c.sendAction('updateFilters');
 

--- a/src/client/app/templates/components/custom-property/property-list.hbs
+++ b/src/client/app/templates/components/custom-property/property-list.hbs
@@ -1,7 +1,7 @@
 <div class="custom-property-list">
 	{{#each uiList as |item|}}
 		{{component (concat "custom-property/" (custom-property-type item.type) )
-			label=item.name value=(get config item.name)
+			label=item.label value=(get config item.name)
 			config=config
 			uiItem=item disabled=disabled columns=columns}}
 	{{/each}}

--- a/src/client/app/templates/components/run-details.hbs
+++ b/src/client/app/templates/components/run-details.hbs
@@ -43,18 +43,23 @@
         <div>
             Output {{model.run.summary.outputitems}} items
         </div>
-        <div>
-            <i class="fa fa-exclamation-triangle error-color"></i>
-			{{model.run.errorcount}} Error(s)
-        </div>
-        <div>
-            <i class="fa fa-ban warning-color"></i>
-			Removed {{model.run.droppedcount}} item(s)
-        </div>
-        <div>
-            <i class="fa fa-exclamation-triangle warning-color"></i>
-			{{model.run.warningcount}} Warning(s)
-        </div>
+        <div id="errorTypes">
+			<div id="errorTypeError" {{action "toggleErrorType" "errorTypeError" "Error"}}
+                 class="rule-selectable {{if (eq type 'Error') 'selected'}}">
+				<i class="fa fa-exclamation-triangle error-color"></i>
+				{{model.run.errorcount}} Error(s)
+			</div>
+			<div id="errorTypeDropped" {{action "toggleErrorType" "errorTypeDropped" "Dropped"}}
+                 class="rule-selectable {{if (eq type 'Dropped') 'selected'}}">
+				<i class="fa fa-ban warning-color"></i>
+				Removed {{model.run.droppedcount}} item(s)
+			</div>
+			<div id="errorTypeWarning" {{action "toggleErrorType" "errorTypeWarning" "Warning"}}
+                 class="rule-selectable {{if (eq type 'Warning') 'selected'}}">
+				<i class="fa fa-exclamation-triangle warning-color"></i>
+				{{model.run.warningcount}} Warning(s)
+			</div>
+		</div>
         <div class="run-section-break" />
 		<div id="rulesTable" class="section-content">
 			{{#each ruleData as |ruleInstance index|}}

--- a/src/common/dataDb.js
+++ b/src/common/dataDb.js
@@ -90,6 +90,8 @@ class data {
                             filter = false;
                         }
 
+                        let index = 0;
+
                         log.forEach( function ( value ) {
 
                             if ( !value.ruleID ) {
@@ -113,12 +115,16 @@ class data {
                             } else if (value.type == 'Dropped') {
                                 resultMap[ rowRuleId ].dropped += 1;
                             }
+                            value.index = index;
 
                             if ( filter ) {
                                 if ( (!type || type == value.type) && (!ruleid || rowRuleId == ruleid ) ) {
                                     filteredLog.push( value );
                                 }
                             }
+
+                            index++;
+
                         } );
 
 

--- a/src/server/routes/logs.js
+++ b/src/server/routes/logs.js
@@ -34,7 +34,7 @@ class LogsRouter extends BaseRouter {
 			var includedReports = [];
 			for (var i = 0; i < log.logs.length; i++) {
 				const report = log.logs[i];
-				const reportID = id + i;	// Reports don't have their own ID. Should they have one? (log name + timestamp + level + ???).
+				const reportID = id + '-' + report.index;	// Reports don't have their own ID. Should they have one? (log name + timestamp + level + ???).
 				const reportType = report.type;
 				const reportWhen = report.when;
 				const reportProblemFile = report.problemFile;

--- a/src/validator/RuleSet.js
+++ b/src/validator/RuleSet.js
@@ -210,17 +210,29 @@ class RuleSet {
 	 */
 	static get ConfigProperties() {
 		return  [
-			{
+			/*{
 				name: 'errorsToAbort',
 				label: 'How many total errors before abort?',
 				type: 'integer',
 				tooltip: 'Stop execution when these many errors occur.'
+			},*/ //hide from UI
+			{
+				name: 'droppedPctToAbort',
+				label: 'How many dropped items as a percentage of the total before aborting?',
+				type: 'number',
+				tooltip: 'Stop execution when this percent of items are dropped.'
+			},
+			{
+				name: 'droppedToAbort',
+				label: 'How many total dropped items before aborting?',
+				type: 'integer',
+				tooltip: 'Stop execution when these many dropped items occur.'
 			},
 			{
 				name: 'warningsToAbort',
-				label: 'How many total warnings before abort?',
+				label: 'How many total warnings before aborting?',
 				type: 'integer',
-				tooltip: 'Stop execution when these many warnings occur.'
+				tooltip: 'Stop execution when this many warnings occur.'
 			}
 		];
 	}
@@ -262,6 +274,7 @@ function addRules(rules) {
 
 		dstRule.config.errorsToAbort = cleanNumber(dstRule.config.errorsToAbort, this.general.config.singleRuleErrorsToAbort);
 		dstRule.config.warningsToAbort = cleanNumber(dstRule.config.warningsToAbort, this.general.config.singleRuleWarningsToAbort);
+		dstRule.config.droppedToAbort = cleanNumber(dstRule.config.droppedToAbort, this.general.config.singleRuleDroppedToAbort);
 
 		this.rules.push(dstRule);
 		this.ruleMap[dstRule.config.id] = dstRule;
@@ -285,18 +298,25 @@ function addGeneralConfig() {
 
 	config.errorsToAbort = cleanNumber(config.errorsToAbort, 1);
 	config.warningsToAbort = cleanNumber(config.warningsToAbort);
+	config.droppedToAbort = cleanNumber(config.droppedToAbort);
+	config.droppedPctToAbort = cleanNumber(config.droppedPctToAbort, parseFloat);
 	config.singleRuleErrorsToAbort = cleanNumber(config.singleRuleErrorsToAbort);
+	config.singleRuleDroppedToAbort = cleanNumber(config.singleRuleDroppedToAbort);
 	config.singleRuleWarningsToAbort = cleanNumber(config.singleRuleWarningsToAbort);
 
 
 }
 
-function cleanNumber(value, defaultVal) {
+function cleanNumber(value, defaultVal, fn) {
 
 	let retVal = value;
 
+	if(!fn) {
+		fn = parseInt;
+	}
+
 	if(typeof retVal === "string") {
-		retVal = parseInt(retVal);
+		retVal = fn(retVal);
 	}
 
 	if(retVal == null || isNaN(retVal)) {

--- a/src/validator/tests/unit/test-validator-errorhandling.js
+++ b/src/validator/tests/unit/test-validator-errorhandling.js
@@ -305,7 +305,7 @@ QUnit.test( "Abort on two warnings", function(assert) {
             assert.equal(vldtr.abort, true, "Expected run to fail");
 
             assert.ok(vldtr.logger.getCount(ErrorHandlerAPI.WARNING) == 2, "Expected at 2 warnings");
-            assert.ok(vldtr.logger.getCount(ErrorHandlerAPI.ERROR) == 2, "Expected two errors (abort & no results)");
+            assert.ok(vldtr.logger.getCount(ErrorHandlerAPI.ERROR) == 1, "Expected one errors (abort)");
 
         },
         done);
@@ -404,7 +404,7 @@ QUnit.test( "Pass rule errors, Abort on errors", function(assert) {
         (runId, log, ruleSetID, inputFile, outputFile) => {
             assert.equal(vldtr.abort, true, "Expected run to fail");
 
-            assert.ok(vldtr.logger.getCount(ErrorHandlerAPI.ERROR) == 4, "Expected four errors");
+            assert.ok(vldtr.logger.getCount(ErrorHandlerAPI.ERROR) == 3, "Expected three errors");
         },
         done);
 
@@ -622,6 +622,182 @@ QUnit.test( "Exclude row shouldn't abort", function(assert) {
     vldtr.runRuleset("src/validator/tests/testDataCSVFile.csv", "output.csv", 'UTF8');
 
 });
+
+    QUnit.test( "Exclude row abort on 1 global", function(assert) {
+        const config = getDefaultConfig();
+
+        const ruleset = {
+            name : "Test Data Ruleset",
+            rules : [
+                {
+                    filename : "RulePassFail",
+                    config : {
+                        id : 1,
+                        rows: {
+                            "2": ErrorHandlerAPI.ERROR
+                        },
+                        onError: 'excludeRow'
+                    }
+                }
+            ],
+            general : { config : {
+                "errorsToAbort": 1,
+                droppedToAbort: 1
+            }},
+            parser: {
+                filename: "CSVParser",
+                config: {
+                    numHeaderRows : 1
+                }
+            }
+        };
+
+        const done = assert.async();
+
+        const dbProxy = new DataProxy(ruleset,
+            (runId, log, ruleSetID, inputFile, outputFile) => {
+                assert.equal(vldtr.abort, true, "Expected run to fail");
+            },
+            done);
+
+
+        const vldtr = new validator(config, dbProxy.getDataObj());
+
+        vldtr.runRuleset("src/validator/tests/testDataCSVFile.csv", "output.csv", 'UTF8');
+
+    });
+
+    QUnit.test( "Exclude row abort on 2 global has 1", function(assert) {
+        const config = getDefaultConfig();
+
+        const ruleset = {
+            name : "Test Data Ruleset",
+            rules : [
+                {
+                    filename : "RulePassFail",
+                    config : {
+                        id : 1,
+                        rows: {
+                            "2": ErrorHandlerAPI.ERROR
+                        },
+                        onError: 'excludeRow'
+                    }
+                }
+            ],
+            general : { config : {
+                "errorsToAbort": 1,
+                droppedToAbort: 2
+            }},
+            parser: {
+                filename: "CSVParser",
+                config: {
+                    numHeaderRows : 1
+                }
+            }
+        };
+
+        const done = assert.async();
+
+        const dbProxy = new DataProxy(ruleset,
+            (runId, log, ruleSetID, inputFile, outputFile) => {
+                assert.equal(vldtr.abort, false, "Expected run to pass");
+            },
+            done);
+
+
+        const vldtr = new validator(config, dbProxy.getDataObj());
+
+        vldtr.runRuleset("src/validator/tests/testDataCSVFile.csv", "output.csv", 'UTF8');
+
+    });
+
+    QUnit.test( "Exclude row abort on 1 on rule", function(assert) {
+        const config = getDefaultConfig();
+
+        const ruleset = {
+            name : "Test Data Ruleset",
+            rules : [
+                {
+                    filename : "RulePassFail",
+                    config : {
+                        id : 1,
+                        rows: {
+                            "2": ErrorHandlerAPI.ERROR
+                        },
+                        onError: 'excludeRow',
+                        droppedToAbort: 1
+                    }
+                }
+            ],
+            general : { config : {
+                "errorsToAbort": 1
+            }},
+            parser: {
+                filename: "CSVParser",
+                config: {
+                    numHeaderRows : 1
+                }
+            }
+        };
+
+        const done = assert.async();
+
+        const dbProxy = new DataProxy(ruleset,
+            (runId, log, ruleSetID, inputFile, outputFile) => {
+                assert.equal(vldtr.abort, true, "Expected run to fail");
+            },
+            done);
+
+
+        const vldtr = new validator(config, dbProxy.getDataObj());
+
+        vldtr.runRuleset("src/validator/tests/testDataCSVFile.csv", "output.csv", 'UTF8');
+
+    });
+
+    QUnit.test( "Exclude row abort on 2 on rule has 1", function(assert) {
+        const config = getDefaultConfig();
+
+        const ruleset = {
+            name : "Test Data Ruleset",
+            rules : [
+                {
+                    filename : "RulePassFail",
+                    config : {
+                        id : 1,
+                        rows: {
+                            "2": ErrorHandlerAPI.ERROR
+                        },
+                        onError: 'excludeRow',
+                        droppedToAbort: 2
+                    }
+                }
+            ],
+            general : { config : {
+                "errorsToAbort": 1
+            }},
+            parser: {
+                filename: "CSVParser",
+                config: {
+                    numHeaderRows : 1
+                }
+            }
+        };
+
+        const done = assert.async();
+
+        const dbProxy = new DataProxy(ruleset,
+            (runId, log, ruleSetID, inputFile, outputFile) => {
+                assert.equal(vldtr.abort, false, "Expected run to pass");
+            },
+            done);
+
+
+        const vldtr = new validator(config, dbProxy.getDataObj());
+
+        vldtr.runRuleset("src/validator/tests/testDataCSVFile.csv", "output.csv", 'UTF8');
+
+    });
 
 QUnit.test( "Exclude row actually removed", function(assert) {
     const config = getDefaultConfig();
@@ -877,6 +1053,93 @@ QUnit.test( "internal rowId column actually removed", function(assert) {
 
 
         vldtr.runRuleset("src/validator/tests/testDataCSVFile2.csv", "output2.csv", 'UTF8');
+
+    });
+
+
+    QUnit.test( "Exclude 25% rows abort on 20%", function(assert) {
+        const config = getDefaultConfig();
+
+        const ruleset = {
+            name : "Test Data Ruleset",
+            rules : [
+                {
+                    filename : "RulePassFail",
+                    config : {
+                        id : 1,
+                        rows: {
+                            "2": ErrorHandlerAPI.ERROR
+                        },
+                        onError: 'excludeRow'
+                    }
+                }
+            ],
+            general : { config : {
+                droppedPctToAbort: 20
+            }},
+            parser: {
+                filename: "CSVParser",
+                config: {
+                    numHeaderRows : 1
+                }
+            }
+        };
+
+        const done = assert.async();
+
+        const dbProxy = new DataProxy(ruleset,
+            (runId, log, ruleSetID, inputFile, outputFile) => {
+                assert.equal(vldtr.abort, true, "Expected run to fail");
+            },
+            done);
+
+
+        const vldtr = new validator(config, dbProxy.getDataObj());
+
+        vldtr.runRuleset("src/validator/tests/testDataCSVFile.csv", "output.csv", 'UTF8');
+
+    });
+
+    QUnit.test( "Exclude 25% rows abort on 50%", function(assert) {
+        const config = getDefaultConfig();
+
+        const ruleset = {
+            name : "Test Data Ruleset",
+            rules : [
+                {
+                    filename : "RulePassFail",
+                    config : {
+                        id : 1,
+                        rows: {
+                            "2": ErrorHandlerAPI.ERROR
+                        },
+                        onError: 'excludeRow'
+                    }
+                }
+            ],
+            general : { config : {
+                droppedPctToAbort: 50
+            }},
+            parser: {
+                filename: "CSVParser",
+                config: {
+                    numHeaderRows : 1
+                }
+            }
+        };
+
+        const done = assert.async();
+
+        const dbProxy = new DataProxy(ruleset,
+            (runId, log, ruleSetID, inputFile, outputFile) => {
+                assert.equal(vldtr.abort, false, "Expected run to pass");
+            },
+            done);
+
+
+        const vldtr = new validator(config, dbProxy.getDataObj());
+
+        vldtr.runRuleset("src/validator/tests/testDataCSVFile.csv", "output.csv", 'UTF8');
 
     });
 


### PR DESCRIPTION
Addresses #181  and #182
Removed the Error count limits from the UI (can only be 1 now)
Added Dropped item limit to ruleset and per rule
Added Dropped item percent of total to the ruleset
Fixed label in ruleset properties
Made Error types selectable for filtering on run details