### PR TITLE
Feature/configuredrule access control

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,26 @@ If a custom importer is used as part of the [ruleset][ruleset], import configura
 }
 ```
 
+## Using the simulated S3
+
+Part of the test suite is a simulated S3 using Scality Zenko Cloudserver (scality/s3server on Docker hub), and the 
+S3Importer and S3Exporter can be configured to use it. The default access keys are:
+
+user: accessKey1
+
+password: verySecretKey1
+
+#### Uploading files via Cyberduck 
+
+Unfortunately, the latest versions of Cyberduck removed the ability to connect to non-https S3 like storage systems, so you'll
+need to grab an old version:
+
+Windows: https://update.cyberduck.io/windows/Cyberduck-Installer-4.8.4.19355.exe 
+Mac: https://update.cyberduck.io/Cyberduck-4.8.4.19355.zip
+
+Once installed double click on `S3 (HTTP).cyberduckprofile` in the root PLUTO folder to setup a connection, and use the keys
+above to access it.
+
 ## Starting dev database and running locally
 To run the validator and server locally for dev and debugging purposes, a separate debug database can be started via:
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Windows: https://update.cyberduck.io/windows/Cyberduck-Installer-4.8.4.19355.exe
 Mac: https://update.cyberduck.io/Cyberduck-4.8.4.19355.zip
 
 Once installed double click on `S3 (HTTP).cyberduckprofile` in the root PLUTO folder to setup a connection, and use the keys
-above to access it.
+above to access it. The Simulated S3 source uses the bucket `test`, and the Simulated S3 target uses `testoutput`.
 
 ## Starting dev database and running locally
 To run the validator and server locally for dev and debugging purposes, a separate debug database can be started via:

--- a/S3 (HTTP).cyberduckprofile
+++ b/S3 (HTTP).cyberduckprofile
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>Protocol</key>
+        <string>s3</string>
+        <key>Vendor</key>
+        <string>s3-http</string>
+        <key>Scheme</key>
+        <string>http</string>
+        <key>Description</key>
+        <string>S3 (HTTP)</string>
+        <key>Default Port</key>
+        <string>8000</string>
+        <key>Hostname Configurable</key>
+        <true/>
+        <key>Port Configurable</key>
+        <true/>
+        <key>Username Configurable</key>
+        <true/>
+    </dict>
+</plist>

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "build_docs": "sh build/bin/buildDocs.sh",
     "load_devdata": "node database/dbloader/importRulesets.js -v src/runtime/configs/validatorConfig.json -r src/runtime/rulesets",
     "tag_images": "sh build/bin/tagImages.sh",
-    "start_test_nginx": "docker run -v $PWD/dev_nginx.conf:/etc/nginx/nginx.conf:ro -p 9001:9001 -p 9002:9002 -p 9003:9003 -p 9004:9004 --name dev_pluto_nginx -d nginx:stable-alpine"
+    "start_dev_nginx": "docker run -v $PWD/dev_nginx.conf:/etc/nginx/nginx.conf:ro -p 9001:9001 -p 9002:9002 -p 9003:9003 -p 9004:9004 --name dev_pluto_nginx -d nginx:stable-alpine",
+    "start_dev_s3": "docker run -p 8000:8000 --name pluto_s3server -d scality/s3server"
   },
   "repository": {
     "type": "git",
@@ -28,6 +29,7 @@
   },
   "homepage": "https://github.com/unchartedsoftware/PLUTO#readme",
   "dependencies": {
+    "aws-sdk": "^2.165.0",
     "body-parser": "^1.17.2",
     "bottleneck": "^1.16.0",
     "commander": "^2.9.0",

--- a/src/client/app/controllers/edit-configured-rule.js
+++ b/src/client/app/controllers/edit-configured-rule.js
@@ -41,7 +41,7 @@ export default Ember.Controller.extend({
 		return title;
 
 	}),
-	disabled: Ember.computed('model.rule.canedit', function() {
+	disableEdit: Ember.computed('model.rule.canedit', function() {
 		const canedit = this.get('model.rule.canedit');
 		return !canedit;
 

--- a/src/client/app/controllers/edit-configured-rule.js
+++ b/src/client/app/controllers/edit-configured-rule.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import moment from 'moment';
 
 export default Ember.Controller.extend({
 	ajax: Ember.inject.service(),
@@ -45,6 +46,27 @@ export default Ember.Controller.extend({
 		const canedit = this.get('model.rule.canedit');
 		return !canedit;
 
+	}),
+	ownedBy: Ember.computed('model.rule.ownerGroup', function() {
+		let group = this.get('model.rule.ownerGroup');
+		if(group) return group;
+
+		return 'Nobody';
+	}),
+	lastEditedBy: Ember.computed('model.rule.updateUser', function() {
+		let user = this.get('model.rule.updateUser');
+		if(user) return user;
+
+		return 'Unknown';
+	}),
+	lastEdited: Ember.computed('model.rule.updateTime', function() {
+		let changeTime = this.get('model.rule.updateTime');
+
+		if(changeTime) {
+			return moment(changeTime).format('MMMM Do YYYY, h:mm a');
+		}
+
+		return 'Unknown';
 	}),
 	linkedtarget: Ember.computed('model.rule.config.linkedtargetid', function() {
 		const type = this.get('model.rule.type');

--- a/src/client/app/models/configuredrule.js
+++ b/src/client/app/models/configuredrule.js
@@ -25,9 +25,9 @@ export default DS.Model.extend(Validations, {
 	group: DS.attr('string'),
 	version: DS.attr('number'),
 	canedit: DS.attr('boolean'),
-	ownergroup: DS.attr('string'),
-	updateuser: DS.attr('string'),
-	updatetime: DS.attr('date'),
+	ownerGroup: DS.attr('string'),
+	updateUser: DS.attr('string'),
+	updateTime: DS.attr('date'),
 	deleted: DS.attr('boolean'),
 	ui: DS.attr()
 });

--- a/src/client/app/templates/edit-configured-rule.hbs
+++ b/src/client/app/templates/edit-configured-rule.hbs
@@ -32,13 +32,14 @@
 			onchange=(action "chooseBase")
 			selected=base
 			allowClear=true
+			disabled=disableEdit
 			as |baseChoice|}}
 				{{baseChoice.id}}
 		{{/power-select}}
 	</div>
 	<div>
 		Properties
-		{{component 'custom-property.property-list' uiList=base.ui.properties config=model.rule.config disabled=disabled}}
+		{{component 'custom-property.property-list' uiList=base.ui.properties config=model.rule.config disabled=disableEdit}}
 	</div>
 
 	{{#if (eq model.rule.type "source") }}
@@ -50,6 +51,7 @@
 				selected=linkedtarget
 				options=model.defaultTargets
 				allowClear=true
+				disabled=disableEdit
 				as |targetChoice|}}
 				{{targetChoice.rule_id}}: {{targetChoice.description}}
 			{{/power-select}}
@@ -57,12 +59,16 @@
 	{{/if}}
 </div>
 
-{{#bs-button onClick=(action "saveRule") disabled=(v-get model.rule 'isInvalid') }}
-    Save
-{{/bs-button}}
+{{#unless disableEdit}}
 
-{{#unless (v-get model.rule 'isValid')}}
-	<span class="error-color">Correct the errors before saving</span>
+	{{#bs-button onClick=(action "saveRule") disabled=(v-get model.rule 'isInvalid') }}
+		Save
+	{{/bs-button}}
+
+	{{#unless (v-get model.rule 'isValid')}}
+		<span class="error-color">Correct the errors before saving</span>
+	{{/unless}}
+
 {{/unless}}
 
 {{outlet}}

--- a/src/client/app/templates/edit-configured-rule.hbs
+++ b/src/client/app/templates/edit-configured-rule.hbs
@@ -4,6 +4,11 @@
         <i class="fa fa-angle-double-left"></i>
 	{{/link-to}}
     <h2>{{title}} {{model.rule.description}}</h2>
+
+    <div class="authDetails">
+        <div>Owned by {{ownedBy}}</div>
+        <div>Lasted edited on {{lastEdited}} by {{lastEditedBy}}</div>
+    </div>
 </div>
 
 <div>

--- a/src/client/app/templates/edit-ruleset.hbs
+++ b/src/client/app/templates/edit-ruleset.hbs
@@ -91,7 +91,7 @@ Process URL: {{processURL}}
 
 				{{component 'custom-property.property-list' uiList=source.ui.properties
 				config=model.ruleset.source.config
-				disabled=disabled
+				disabled=disableEdit
 				columns=columns}}
 
 			{{/if}}
@@ -156,7 +156,7 @@ Process URL: {{processURL}}
 
 					{{component 'custom-property.property-list' uiList=rulesettarget.ui.properties
 					config=model.ruleset.target.config
-					disabled=disabled
+					disabled=disableEdit
 					columns=columns}}
 
 				{{/if}}
@@ -187,7 +187,7 @@ Process URL: {{processURL}}
 				{{component 'custom-property.property-list'
 				uiList=(compute (action "getUiProperties") model.importers model.ruleset.import.filename)
 				config=model.ruleset.import.config
-				disabled=disabled
+				disabled=disableEdit
 				columns=columns}}
 			{{/c.collapsable}}
 		{{/edit-ruleset/collapse}}
@@ -214,7 +214,7 @@ Process URL: {{processURL}}
 				{{component 'custom-property.property-list'
 				uiList=(compute (action "getUiProperties") model.exporters model.ruleset.export.filename)
 				config=model.ruleset.export.config
-				disabled=disabled
+				disabled=disableEdit
 				columns=columns}}
 			{{/c.collapsable}}
 		{{/edit-ruleset/collapse}}
@@ -240,7 +240,7 @@ Process URL: {{processURL}}
 			{{component 'custom-property.property-list'
 			uiList=(compute (action "getUiProperties") model.parsers model.ruleset.parser.filename)
 			config=model.ruleset.parser.config
-			disabled=disabled
+			disabled=disableEdit
 			columns=columns}}
 		{{/c.collapsable}}
 	{{/edit-ruleset/collapse}}
@@ -256,7 +256,7 @@ Process URL: {{processURL}}
 			{{component 'custom-property.property-list'
 			uiList=(compute (action "getUiProperties") model.rulesetconfiguis model.ruleset.general.filename)
 			config=model.ruleset.general.config
-			disabled=disabled
+			disabled=disableEdit
 			columns=columns}}
 		{{/c.collapsable}}
 
@@ -313,7 +313,7 @@ Process URL: {{processURL}}
 				{{component 'custom-property.property-list'
 				uiList=(compute (action "getUiProperties") model.rules ruleInstance.filename)
 				config=(get ruleInstance "config")
-				disabled=disabled
+				disabled=disableEdit
 				columns=columns
 				}}
 			{{/c.collapsable}}

--- a/src/common/dataDb.js
+++ b/src/common/dataDb.js
@@ -841,7 +841,7 @@ class data {
      * @param rule_id the name of the rule.
      * @return a promise to an object describing a rule.
      */
-    retrieveRule ( rule_id, version, dbId, group, admin ) {
+    retrieveRule ( rule_id, version, dbId, group, admin, rulesLoader ) {
 
         let isAdmin = admin === true;
 
@@ -849,7 +849,7 @@ class data {
             getRule( this.db, rule_id, version, dbId, this.tables).then((result) => {
                 if ( result.rows.length > 0 ) {
 
-                    var rule = getRuleResult(result.rows[0], isAdmin, group);
+                    var rule = getRuleResult(result.rows[0], isAdmin, group, rulesLoader);
 
                     resolve( rule );
 
@@ -863,7 +863,7 @@ class data {
 
     }
 
-    getRules ( page, size, filters, group, admin ) {
+    getRules ( page, size, filters, group, admin, rulesLoader ) {
 
         let isAdmin = admin === true;
 
@@ -984,7 +984,7 @@ class data {
                 var rules = [];
 
                 result.rows.forEach( ( row ) => {
-                    rules.push( getRuleResult(row, isAdmin, group) );
+                    rules.push( getRuleResult(row, isAdmin, group, rulesLoader) );
                 } );
 
                 resolve( {
@@ -1059,11 +1059,6 @@ class data {
             } else {
                 update.call(this);
             }
-
-
-
-
-
 
         });
 
@@ -1401,7 +1396,7 @@ function checkCanChangeRule(db, tables, rule, group, admin) {
 
 }
 
-function getRuleResult(row, isAdmin, group) {
+function getRuleResult(row, isAdmin, group, rulesLoader) {
     let rule = {
         id: row.id,
         version: row.version,
@@ -1422,6 +1417,28 @@ function getRuleResult(row, isAdmin, group) {
     } else {
         rule.canedit = true;
     }
+
+    //hide/remove protected items if the user is not authorized
+    if(!rule.canedit && rulesLoader && rule.base && rule.config) {
+
+        let baseRule = rulesLoader.rulePropertiesMap[rule.base];
+
+        if(baseRule && baseRule.attributes && baseRule.attributes.ui && baseRule.attributes.ui.properties) {
+            baseRule.attributes.ui.properties.forEach((prop) => {
+
+                if(prop.private)
+                {
+                    if(prop.type === 'string') {
+                        rule.config[prop.name] = '********'
+                    } else {
+                        delete rule.config[prop.name];
+                    }
+                }
+
+            });
+        }
+    }
+
     return rule;
 }
 

--- a/src/common/dataDb.js
+++ b/src/common/dataDb.js
@@ -1303,7 +1303,7 @@ function getRulesetFromRow(row, ruleset_id, isAdmin, group, ruleLoader) {
     dbRuleset.update_user = row.update_user;
     dbRuleset.update_time = row.update_time;
 
-    if (dbRuleset.group && !isAdmin && dbRuleset.group !== group) {
+    if (dbRuleset.owner_group && !isAdmin && dbRuleset.owner_group !== group) {
         dbRuleset.canedit = false;
     } else {
         dbRuleset.canedit = true;
@@ -1429,7 +1429,7 @@ function getRuleResult(row, isAdmin, group, rulesLoader) {
                 if(prop.private)
                 {
                     if(prop.type === 'string') {
-                        rule.config[prop.name] = '********'
+                        rule.config[prop.name] = '********';
                     } else {
                         delete rule.config[prop.name];
                     }

--- a/src/common/ruleLoader.js
+++ b/src/common/ruleLoader.js
@@ -218,7 +218,7 @@ class RuleLoader {
 		return null;
 	}
 
-	getDbRule(id) {
+	getDbRule(id, group, admin) {
 
 		return new Promise((resolve) => {
 			if (!this.db) {
@@ -226,7 +226,7 @@ class RuleLoader {
 				return;
 			}
 
-			this.db.retrieveRule(id).then((rule) => {
+			this.db.retrieveRule(id, undefined, undefined, group, admin, this).then((rule) => {
 				resolve(rule);
 			}, () => {
 				resolve(null);

--- a/src/rules/S3Export.js
+++ b/src/rules/S3Export.js
@@ -69,37 +69,45 @@ class Exporter {
 				name: 'bucket',
 				label: 'Bucket name',
 				type: 'string',
-				tooltip: 'The bucket name'
+				tooltip: 'The bucket name',
+				hidden: true
 			},
 			{
 				name: 'endpoint',
 				label: 'base URL endpoint (e.g. s3.amazonaws.com)',
 				type: 'string',
-				tooltip: 'The URL (without protocol), including port if not standard'
+				tooltip: 'The URL (without protocol), including port if not standard',
+				hidden: true
 			},
 			{
 				name: 'sslEnabled',
 				label: 'Use secure transfer (SSL/TLS)',
 				type: 'boolean',
-				tooltip: 'If checked, all communications with the storage will go through encrypted SSL/TLS channel'
+				tooltip: 'If checked, all communications with the storage will go through encrypted SSL/TLS channel',
+				hidden: true
 			},
 			{
 				name: 'forcePathStyle',
 				label: 'Force Path Style (S3 compatible systems)',
 				type: 'boolean',
-				tooltip: 'If checked, forcePathStyle is set to true, used by some S3 compatible systems'
+				tooltip: 'If checked, forcePathStyle is set to true, used by some S3 compatible systems',
+				hidden: true
 			},
 			{
 				name: 'accessId',
 				label: 'Access Key ID',
 				type: 'string',
-				tooltip: ''
+				tooltip: '',
+				private: true,
+				hidden: true
 			},
 			{
 				name: 'accessKey',
 				label: 'Secret Access Key',
 				type: 'string',
-				tooltip: ''
+				tooltip: '',
+				private: true,
+				hidden: true
 			}
 		];
 	}

--- a/src/rules/S3Export.js
+++ b/src/rules/S3Export.js
@@ -1,0 +1,114 @@
+const fs = require('fs-extra');
+const path = require("path");
+
+const AWS = require('aws-sdk');
+var http = require('http');
+http.globalAgent.maxSockets = 250;
+
+var https = require('https');
+https.globalAgent.maxSockets = 250;
+
+class Exporter {
+	constructor(config) {
+		this.config = config;
+	}
+
+	exportFile(sourceFileName, runId, errorLog) {
+
+		return new Promise((resolve, reject) => {
+
+			if(!this.config.file) {
+				reject('No target file name.');
+				return;
+			}
+
+			if(sourceFileName) {
+
+				const s3 = new AWS.S3({
+					accessKeyId: this.config.accessId,
+					secretAccessKey: this.config.accessKey,
+					endpoint: this.config.endpoint,
+					sslEnabled: this.config.sslEnabled || false,
+					s3ForcePathStyle: this.config.forcePathStyle
+				});
+
+				let file = fs.createReadStream(sourceFileName);
+
+				if(!file) {
+					reject('Error opening file for export: ' + sourceFileName);
+				}
+
+				let params = {
+					Bucket: this.config.bucket,
+					Key: this.config.file,
+					Body: file
+				};
+
+				s3.upload(params, (err) => {
+					if(err) {
+						reject(err);
+						return;
+					}
+					resolve(this.config.file);
+				});
+
+			} else {
+				resolve(null);
+			}
+		});
+	}
+
+	static get Type() {
+		return "exporter";
+	}
+
+	static get ConfigProperties() {
+		return [
+			{
+				name: 'file',
+				label: 'Source file path',
+				type: 'string',
+				tooltip: 'The path to a file in the bucket'
+			},
+			{
+				name: 'bucket',
+				label: 'Bucket name',
+				type: 'string',
+				tooltip: 'The bucket name'
+			},
+			{
+				name: 'endpoint',
+				label: 'base URL endpoint (e.g. s3.amazonaws.com)',
+				type: 'string',
+				tooltip: 'The URL (without protocol), including port if not standard'
+			},
+			{
+				name: 'sslEnabled',
+				label: 'Use secure transfer (SSL/TLS)',
+				type: 'boolean',
+				tooltip: 'If checked, all communications with the storage will go through encrypted SSL/TLS channel'
+			},
+			{
+				name: 'forcePathStyle',
+				label: 'Force Path Style (S3 compatible systems)',
+				type: 'boolean',
+				tooltip: 'If checked, forcePathStyle is set to true, used by some S3 compatible systems'
+			},
+			{
+				name: 'accessId',
+				label: 'Access Key ID',
+				type: 'string',
+				tooltip: ''
+			},
+			{
+				name: 'accessKey',
+				label: 'Secret Access Key',
+				type: 'string',
+				tooltip: ''
+			}
+		];
+	}
+
+};
+
+module.exports = Exporter;

--- a/src/rules/S3Export.js
+++ b/src/rules/S3Export.js
@@ -2,11 +2,6 @@ const fs = require('fs-extra');
 const path = require("path");
 
 const AWS = require('aws-sdk');
-var http = require('http');
-http.globalAgent.maxSockets = 250;
-
-var https = require('https');
-https.globalAgent.maxSockets = 250;
 
 class Exporter {
 	constructor(config) {

--- a/src/rules/S3Import.js
+++ b/src/rules/S3Import.js
@@ -63,37 +63,45 @@ class Importer {
                 name: 'bucket',
                 label: 'Bucket name',
                 type: 'string',
-                tooltip: 'The bucket name'
+                tooltip: 'The bucket name',
+                hidden: true
             },
             {
                 name: 'endpoint',
                 label: 'base URL endpoint (e.g. s3.amazonaws.com)',
                 type: 'string',
-                tooltip: 'The URL (without protocol), including port if not standard'
+                tooltip: 'The URL (without protocol), including port if not standard',
+                hidden: true
             },
             {
                 name: 'sslEnabled',
                 label: 'Use secure transfer (SSL/TLS)',
                 type: 'boolean',
-                tooltip: 'If checked, all communications with the storage will go through encrypted SSL/TLS channel'
+                tooltip: 'If checked, all communications with the storage will go through encrypted SSL/TLS channel',
+                hidden: true
             },
             {
                 name: 'forcePathStyle',
                 label: 'Force Path Style (S3 compatible systems)',
                 type: 'boolean',
-                tooltip: 'If checked, forcePathStyle is set to true, used by some S3 compatible systems'
+                tooltip: 'If checked, forcePathStyle is set to true, used by some S3 compatible systems',
+                hidden: true
             },
             {
                 name: 'accessId',
                 label: 'Access Key ID',
                 type: 'string',
-                tooltip: ''
+                tooltip: '',
+                private: true,
+                hidden: true
             },
             {
                 name: 'accessKey',
                 label: 'Secret Access Key',
                 type: 'string',
-                tooltip: ''
+                tooltip: '',
+                private: true,
+                hidden: true
             }
         ];
     }

--- a/src/rules/S3Import.js
+++ b/src/rules/S3Import.js
@@ -1,0 +1,103 @@
+const fs = require('fs-extra');
+const path = require("path");
+
+const AWS = require('aws-sdk');
+
+class Importer {
+	constructor(config) {
+		this.config = config;
+	}
+
+	importFile(targetFileName) {
+
+        return new Promise((resolve, reject) => {
+
+            if(!targetFileName) {
+                reject('No target file name');
+            }
+
+            if(!this.config.file) {
+                reject('No source file name');
+            }
+
+
+            const s3 = new AWS.S3({
+                accessKeyId: this.config.accessId,
+                secretAccessKey: this.config.accessKey,
+                endpoint: this.config.endpoint,
+                sslEnabled: this.config.sslEnabled || false,
+                s3ForcePathStyle: this.config.forcePathStyle
+            });
+
+            let params = {
+                Bucket: this.config.bucket,
+                Key: this.config.file
+            };
+
+            var file = fs.createWriteStream(targetFileName);
+
+            s3.getObject(params).createReadStream()
+                .on('end', () => {
+                    resolve(this.config.file);
+                })
+                .on('error', (error) => {
+                    return reject(error); })
+                .pipe(file);
+
+        });
+    }
+
+    static get Type() {
+        return "importer";
+    }
+
+    static get ConfigProperties() {
+        return [
+            {
+                name: 'file',
+                label: 'Source file path',
+                type: 'string',
+                tooltip: 'The path to a file in the bucket'
+            },
+            {
+                name: 'bucket',
+                label: 'Bucket name',
+                type: 'string',
+                tooltip: 'The bucket name'
+            },
+            {
+                name: 'endpoint',
+                label: 'base URL endpoint (e.g. s3.amazonaws.com)',
+                type: 'string',
+                tooltip: 'The URL (without protocol), including port if not standard'
+            },
+            {
+                name: 'sslEnabled',
+                label: 'Use secure transfer (SSL/TLS)',
+                type: 'boolean',
+                tooltip: 'If checked, all communications with the storage will go through encrypted SSL/TLS channel'
+            },
+            {
+                name: 'forcePathStyle',
+                label: 'Force Path Style (S3 compatible systems)',
+                type: 'boolean',
+                tooltip: 'If checked, forcePathStyle is set to true, used by some S3 compatible systems'
+            },
+            {
+                name: 'accessId',
+                label: 'Access Key ID',
+                type: 'string',
+                tooltip: ''
+            },
+            {
+                name: 'accessKey',
+                label: 'Secret Access Key',
+                type: 'string',
+                tooltip: ''
+            }
+        ];
+    }
+
+}
+
+module.exports = Importer;

--- a/src/rules/manifest.json
+++ b/src/rules/manifest.json
@@ -39,12 +39,20 @@
     {
       "filename":"LocalCopyImport",
       "path": "./LocalCopyImport.js"
+    },
+    {
+      "filename":"S3Import",
+      "path": "./S3Import.js"
     }
   ],
   "exporters" : [
     {
       "filename":"LocalCopyExport",
       "path": "./LocalCopyExport.js"
+    },
+    {
+      "filename":"S3Export",
+      "path": "./S3Export.js"
     }
   ]
 }

--- a/src/runtime/rulesets/rules.json
+++ b/src/runtime/rulesets/rules.json
@@ -3,7 +3,7 @@
     {
       "rule_id": "testSource",
       "type": "source",
-      "description": "test source",
+      "description": "Local",
       "base": "LocalCopyImport",
       "group": "sample",
       "config": {
@@ -13,7 +13,7 @@
     {
       "rule_id": "testSourceTarget",
       "type": "source",
-      "description": "test source",
+      "description": "Local with target",
       "base": "LocalCopyImport",
       "group": "sample",
       "config": {
@@ -24,11 +24,41 @@
     {
       "rule_id": "testTarget",
       "type": "target",
-      "description": "test target",
+      "description": "Local",
       "base": "LocalCopyExport",
       "group": "sample",
       "config": {
         "base": "./tmp"
+      }
+    },
+    {
+      "rule_id": "pluto_s3_source",
+      "type": "source",
+      "description": "Simulated S3",
+      "base": "S3Import",
+      "group": "sample",
+      "config": {
+        "accessKey": "verySecretKey1",
+        "endpoint": "localhost:8000",
+        "sslEnabled": false,
+        "bucket":"test",
+        "forcePathStyle":true,
+        "accessId":"accessKey1"
+      }
+    },
+    {
+      "rule_id": "pluto_s3_target",
+      "type": "target",
+      "description": "Simulated S3",
+      "base": "S3Export",
+      "group": "sample",
+      "config": {
+        "accessKey": "verySecretKey1",
+        "endpoint": "localhost:8000",
+        "sslEnabled": false,
+        "bucket":"testoutput",
+        "forcePathStyle":true,
+        "accessId":"accessKey1"
       }
     }
   ]

--- a/src/server/routes/configuredRules.js
+++ b/src/server/routes/configuredRules.js
@@ -11,6 +11,15 @@ function massageRule(rule, rulesLoader) {
 	rule["database-id"] = id;
 	delete rule.id;
 
+	rule["owner-group"] = rule.owner_group;
+	delete rule.owner_group;
+
+	rule["update-user"] = rule.update_user;
+	delete rule.update_user;
+
+	rule["update-time"] = rule.update_time;
+	delete rule.update_time;
+
 	if(!rule.config) {
 		rule.config = {};
 	}
@@ -27,13 +36,12 @@ function massageRule(rule, rulesLoader) {
 
 		if(baseRule && baseRule.attributes && baseRule.attributes.ui && baseRule.attributes.ui.properties) {
 			baseRule.attributes.ui.properties.forEach((prop) => {
-				if(!rule.config[prop.name]) {
+				if(rule.config[prop.name] == null && prop.private !== true && prop.hidden !== true) {
 					rule.ui.properties.push(prop);
 				}
 			});
 		}
 	}
-
 
 	return rule;
 }
@@ -67,7 +75,7 @@ class ConfiguredRuleRouter extends BaseRouter {
 				version = req.query.version;
 			}
 
-			this.config.data.retrieveRule(id, version, dbId, auth.group, auth.admin).then((rule) => {
+			this.config.data.retrieveRule(id, version, dbId, auth.group, auth.admin, this.config.rulesLoader).then((rule) => {
 				if (!rule) {
 					res.statusMessage = `Unable to retrieve rule '${id}'.`;
 					res.status(404).end();
@@ -107,7 +115,7 @@ class ConfiguredRuleRouter extends BaseRouter {
 				typeFilter: req.query.typeFilter,
 				ownerFilter: req.query.ownerFilter,
 				descriptionFilter: req.query.descriptionFilter
-			}).then((result) => {
+			}, auth.group, auth.admin, this.config.rulesLoader).then((result) => {
 				const rules = [];
 
 				result.rules.forEach(rule => {

--- a/src/server/routes/rulesets.js
+++ b/src/server/routes/rulesets.js
@@ -31,7 +31,7 @@ class RulesetRouter extends BaseRouter {
 				version = req.query.version;
 			}
 
-			this.config.data.retrieveRuleset(id, null, null, version, dbId, auth.group, auth.admin).then((ruleset) => {
+			this.config.data.retrieveRuleset(id, null, this.config.rulesLoader, version, dbId, auth.group, auth.admin).then((ruleset) => {
 				if (!ruleset) {
 					res.statusMessage = `Unable to retrieve ruleset '${id}'.`;
 					res.status(404).end();

--- a/src/validator/RuleSet.js
+++ b/src/validator/RuleSet.js
@@ -4,7 +4,7 @@ const Util = require("../common/Util");
 
 class RuleSet {
 
-	constructor(ruleset, ruleLoader) {
+	constructor(ruleset, rulesLoader) {
 		this.name = ruleset.name;
 		this.filename = ruleset.filename;
 
@@ -54,12 +54,18 @@ class RuleSet {
 
 		addRules.call(this, ruleset.rules);
 		
-		this.addParserDefaults(ruleLoader);
+		this.addParserDefaults(rulesLoader);
+
+		if(!this.canedit && rulesLoader) {
+			privatize.call(this, rulesLoader);
+		}
+
+
 	}
 
-	addParserDefaults(ruleLoader) {
-        if (ruleLoader && this.parser && this.parser.filename) {
-            var parserClass = ruleLoader.parsersMap[this.parser.filename];
+	addParserDefaults(rulesLoader) {
+        if (rulesLoader && this.parser && this.parser.filename) {
+            var parserClass = rulesLoader.parsersMap[this.parser.filename];
             if (parserClass && parserClass.ConfigDefaults) {
                 var defaults = parserClass.ConfigDefaults;
                 for (var key in defaults) {
@@ -107,7 +113,7 @@ class RuleSet {
 		}
 	}
 
-	resolve(ruleLoader, group, admin) {
+	resolve(rulesLoader, group, admin) {
 
 
 
@@ -116,11 +122,11 @@ class RuleSet {
 			let promises = [];
 
 			if(this.source) {
-				promises.push(this.updateSource(ruleLoader, group, admin));
+				promises.push(this.updateSource(rulesLoader, group, admin));
 			}
 
 			if(this.target) {
-				promises.push(this.updateTarget(ruleLoader, group, admin));
+				promises.push(this.updateTarget(rulesLoader, group, admin));
 			}
 
 
@@ -134,9 +140,9 @@ class RuleSet {
 
 	}
 
-	updateSource(ruleLoader, group, admin) {
+	updateSource(rulesLoader, group, admin) {
 		return new Promise((resolve) => {
-			ruleLoader.getDbRule(this.source.filename, group, admin).then((sourceConfig) => {
+			rulesLoader.getDbRule(this.source.filename, group, admin).then((sourceConfig) => {
 				if (sourceConfig && sourceConfig.type === 'source') {
 					this.import = {
 						filename: sourceConfig.base,
@@ -156,7 +162,7 @@ class RuleSet {
 
 					updateConfig(this.source.config, {}, this.target.config);
 
-					this.updateTarget(ruleLoader).then(() => {
+					this.updateTarget(rulesLoader).then(() => {
 						resolve();
 					});
 
@@ -169,9 +175,9 @@ class RuleSet {
 		});
 	}
 
-	updateTarget(ruleLoader, group, admin) {
+	updateTarget(rulesLoader, group, admin) {
 		return new Promise((resolve) => {
-			ruleLoader.getDbRule(this.target.filename, group, admin).then((targetConfig) => {
+			rulesLoader.getDbRule(this.target.filename, group, admin).then((targetConfig) => {
 				if (targetConfig && targetConfig.type === 'target') {
 					this.export = {
 						filename: targetConfig.base,
@@ -305,6 +311,49 @@ function addGeneralConfig() {
 	config.singleRuleWarningsToAbort = cleanNumber(config.singleRuleWarningsToAbort);
 
 
+}
+
+function privatize(rulesLoader) {
+	const items = [
+		'import',
+		'export',
+		'parser'
+	];
+
+	const configuredRules = ['source', 'target'];
+
+	items.forEach((item) => {
+		privatizeItem.call(this, item, rulesLoader, 'filename');
+	});
+
+	configuredRules.forEach((item) => {
+		privatizeItem.call(this, item, rulesLoader, 'base');
+	});
+
+	this.rules.forEach((item) => {
+		privatizeItem.call(this, item, rulesLoader, 'filename');
+	});
+}
+
+function privatizeItem(item, rulesLoader, basePropName) {
+	if(rulesLoader && item.config) {
+		let baseRule = rulesLoader.rulePropertiesMap[item[basePropName]];
+
+		if(baseRule && baseRule.attributes && baseRule.attributes.ui && baseRule.attributes.ui.properties) {
+			baseRule.attributes.ui.properties.forEach((prop) => {
+
+				if(prop.private)
+				{
+					if(prop.type === 'string') {
+						item.config[prop.name] = '********';
+					} else {
+						delete item.config[prop.name];
+					}
+				}
+
+			});
+		}
+	}
 }
 
 function cleanNumber(value, defaultVal, fn) {

--- a/src/validator/RuleSet.js
+++ b/src/validator/RuleSet.js
@@ -107,7 +107,7 @@ class RuleSet {
 		}
 	}
 
-	resolve(ruleLoader) {
+	resolve(ruleLoader, group, admin) {
 
 
 
@@ -116,11 +116,11 @@ class RuleSet {
 			let promises = [];
 
 			if(this.source) {
-				promises.push(this.updateSource(ruleLoader));
+				promises.push(this.updateSource(ruleLoader, group, admin));
 			}
 
 			if(this.target) {
-				promises.push(this.updateTarget(ruleLoader));
+				promises.push(this.updateTarget(ruleLoader, group, admin));
 			}
 
 
@@ -134,9 +134,9 @@ class RuleSet {
 
 	}
 
-	updateSource(ruleLoader) {
+	updateSource(ruleLoader, group, admin) {
 		return new Promise((resolve) => {
-			ruleLoader.getDbRule(this.source.filename).then((sourceConfig) => {
+			ruleLoader.getDbRule(this.source.filename, group, admin).then((sourceConfig) => {
 				if (sourceConfig && sourceConfig.type === 'source') {
 					this.import = {
 						filename: sourceConfig.base,
@@ -169,9 +169,9 @@ class RuleSet {
 		});
 	}
 
-	updateTarget(ruleLoader) {
+	updateTarget(ruleLoader, group, admin) {
 		return new Promise((resolve) => {
-			ruleLoader.getDbRule(this.target.filename).then((targetConfig) => {
+			ruleLoader.getDbRule(this.target.filename, group, admin).then((targetConfig) => {
 				if (targetConfig && targetConfig.type === 'target') {
 					this.export = {
 						filename: targetConfig.base,

--- a/src/validator/RuleSet.js
+++ b/src/validator/RuleSet.js
@@ -323,11 +323,11 @@ function privatize(rulesLoader) {
 	const configuredRules = ['source', 'target'];
 
 	items.forEach((item) => {
-		privatizeItem.call(this, item, rulesLoader, 'filename');
+		privatizeItem.call(this, this[item], rulesLoader, 'filename');
 	});
 
 	configuredRules.forEach((item) => {
-		privatizeItem.call(this, item, rulesLoader, 'base');
+		privatizeItem.call(this, this[item], rulesLoader, 'base');
 	});
 
 	this.rules.forEach((item) => {
@@ -336,7 +336,7 @@ function privatize(rulesLoader) {
 }
 
 function privatizeItem(item, rulesLoader, basePropName) {
-	if(rulesLoader && item.config) {
+	if(item && rulesLoader && item.config) {
 		let baseRule = rulesLoader.rulePropertiesMap[item[basePropName]];
 
 		if(baseRule && baseRule.attributes && baseRule.attributes.ui && baseRule.attributes.ui.properties) {

--- a/src/validator/tests/unit/test-dataDb-rule.js
+++ b/src/validator/tests/unit/test-dataDb-rule.js
@@ -22,8 +22,11 @@ const DataDb = proxyquire("../../../common/dataDb", {
 		}
 	}
 });
+const RuleLoader = require('../../../common/ruleLoader');
 
-QUnit.module("DataDb");
+const ruleLoader = new RuleLoader();
+
+QUnit.module("DataDb - Ruleset");
 
 QUnit.test( "saveRuleSet: Successful", function(assert){
 
@@ -656,6 +659,394 @@ QUnit.test( "deleteRuleSet: admin override wrong group", function(assert){
 		done();
 	}).catch((e) => {
 		assert.ok(false, 'Got exception');
+		done();
+	});
+
+});
+
+
+QUnit.test( "retrieveRuleSet: can edit with no owner", function(assert){
+
+	const ruleset_filename = 'test';
+
+	const config = {
+		query: (text, values) => {
+			if(text.startsWith('SELECT')) {
+				//the get current row test
+				return new Promise((resolve) => {
+					resolve({
+						rows: [
+							{
+								id: 0,
+								version: 0,
+								ruleset_id: ruleset_filename,
+								rules: {},
+								owner_user: null,
+								owner_group: null,
+								update_time: null,
+								name: null,
+								deleted: false
+							}
+						]
+					})
+				});
+
+			} else {
+
+				return new Promise((resolve, reject) => {
+					reject('not expected');
+				});
+			}
+		}
+	};
+
+	const done = assert.async();
+	const data = DataDb(config, true);
+
+	//ruleset_id, rulesetOverrideFile, ruleLoader, version, dbId, group, admin
+	data.retrieveRuleset(ruleset_filename, undefined, undefined, undefined, undefined, undefined, undefined).then((ruleset) => {
+		assert.ok(ruleset, "Expect to have a ruleset");
+		assert.equal(ruleset.canedit, true, "Expect to be able to edit");
+		done();
+	}, (e) => {
+		assert.ok(false, 'Got reject: ' + e);
+		done();
+	}).catch((e) => {
+		assert.ok(false, 'Got exception: ' + e);
+		done();
+	});
+
+});
+
+QUnit.test( "retrieveRuleSet: can edit with same group", function(assert){
+
+	const ruleset_filename = 'test';
+
+	const config = {
+		query: (text, values) => {
+			if(text.startsWith('SELECT')) {
+				//the get current row test
+				return new Promise((resolve) => {
+					resolve({
+						rows: [
+							{
+								id: 0,
+								version: 0,
+								ruleset_id: ruleset_filename,
+								rules: {},
+								owner_user: null,
+								owner_group: 'test',
+								update_time: null,
+								name: null,
+								deleted: false
+							}
+						]
+					})
+				});
+
+			} else {
+
+				return new Promise((resolve, reject) => {
+					reject('not expected');
+				});
+			}
+		}
+	};
+
+	const done = assert.async();
+	const data = DataDb(config, true);
+
+	//ruleset_id, rulesetOverrideFile, ruleLoader, version, dbId, group, admin
+	data.retrieveRuleset(ruleset_filename, undefined, undefined, undefined, undefined, 'test', undefined).then((ruleset) => {
+		assert.ok(ruleset, "Expect to have a ruleset");
+		assert.equal(ruleset.canedit, true, "Expect to be able to edit");
+		done();
+	}, (e) => {
+		assert.ok(false, 'Got reject: ' + e);
+		done();
+	}).catch((e) => {
+		assert.ok(false, 'Got exception: ' + e);
+		done();
+	});
+
+});
+
+QUnit.test( "retrieveRuleSet: can edit as admin", function(assert){
+
+	const ruleset_filename = 'test';
+
+	const config = {
+		query: (text, values) => {
+			if(text.startsWith('SELECT')) {
+				//the get current row test
+				return new Promise((resolve) => {
+					resolve({
+						rows: [
+							{
+								id: 0,
+								version: 0,
+								ruleset_id: ruleset_filename,
+								rules: {},
+								owner_user: null,
+								owner_group: 'test',
+								update_time: null,
+								name: null,
+								deleted: false
+							}
+						]
+					})
+				});
+
+			} else {
+
+				return new Promise((resolve, reject) => {
+					reject('not expected');
+				});
+			}
+		}
+	};
+
+	const done = assert.async();
+	const data = DataDb(config, true);
+
+	//ruleset_id, rulesetOverrideFile, ruleLoader, version, dbId, group, admin
+	data.retrieveRuleset(ruleset_filename, undefined, undefined, undefined, undefined, 'another group', true).then((ruleset) => {
+		assert.ok(ruleset, "Expect to have a ruleset");
+		assert.equal(ruleset.canedit, true, "Expect to be able to edit");
+		done();
+	}, (e) => {
+		assert.ok(false, 'Got reject: ' + e);
+		done();
+	}).catch((e) => {
+		assert.ok(false, 'Got exception: ' + e);
+		done();
+	});
+
+});
+
+QUnit.test( "retrieveRuleSet: can't edit as different group", function(assert){
+
+	const ruleset_filename = 'test';
+
+	const config = {
+		query: (text, values) => {
+			if(text.startsWith('SELECT')) {
+				//the get current row test
+				return new Promise((resolve) => {
+					resolve({
+						rows: [
+							{
+								id: 0,
+								version: 0,
+								ruleset_id: ruleset_filename,
+								rules: {},
+								owner_user: null,
+								owner_group: 'test',
+								update_time: null,
+								name: null,
+								deleted: false
+							}
+						]
+					})
+				});
+
+			} else {
+
+				return new Promise((resolve, reject) => {
+					reject('not expected');
+				});
+			}
+		}
+	};
+
+	const done = assert.async();
+	const data = DataDb(config, true);
+
+	//ruleset_id, rulesetOverrideFile, ruleLoader, version, dbId, group, admin
+	data.retrieveRuleset(ruleset_filename, undefined, undefined, undefined, undefined, 'another group', undefined).then((ruleset) => {
+		assert.ok(ruleset, "Expect to have a ruleset");
+		assert.equal(ruleset.canedit, false, "Expect not to be able to edit");
+		done();
+	}, (e) => {
+		assert.ok(false, 'Got reject: ' + e);
+		done();
+	}).catch((e) => {
+		assert.ok(false, 'Got exception: ' + e);
+		done();
+	});
+
+});
+
+QUnit.test( "retrieveRuleSet: can't edit with no group", function(assert){
+
+	const ruleset_filename = 'test';
+
+	const config = {
+		query: (text, values) => {
+			if(text.startsWith('SELECT')) {
+				//the get current row test
+				return new Promise((resolve) => {
+					resolve({
+						rows: [
+							{
+								id: 0,
+								version: 0,
+								ruleset_id: ruleset_filename,
+								rules: {},
+								owner_user: null,
+								owner_group: 'test',
+								update_time: null,
+								name: null,
+								deleted: false
+							}
+						]
+					})
+				});
+
+			} else {
+
+				return new Promise((resolve, reject) => {
+					reject('not expected');
+				});
+			}
+		}
+	};
+
+	const done = assert.async();
+	const data = DataDb(config, true);
+
+	//ruleset_id, rulesetOverrideFile, ruleLoader, version, dbId, group, admin
+	data.retrieveRuleset(ruleset_filename, undefined, undefined, undefined, undefined, undefined, undefined).then((ruleset) => {
+		assert.ok(ruleset, "Expect to have a ruleset");
+		assert.equal(ruleset.canedit, false, "Expect not to be able to edit");
+		done();
+	}, (e) => {
+		assert.ok(false, 'Got reject: ' + e);
+		done();
+	}).catch((e) => {
+		assert.ok(false, 'Got exception: ' + e);
+		done();
+	});
+
+});
+
+QUnit.test( "retrieveRuleSet: can't see protected properties", function(assert){
+
+	const ruleset_filename = 'test';
+
+	const config = {
+		query: (text, values) => {
+			if(text.startsWith('SELECT')) {
+				//the get current row test
+				return new Promise((resolve) => {
+					resolve({
+						rows: [
+							{
+								id: 0,
+								version: 0,
+								ruleset_id: ruleset_filename,
+								rules: {
+									import: {
+										filename: 'S3Import',
+										config: {
+											accessKey: '12345'
+										}
+									}
+								},
+								owner_user: null,
+								owner_group: 'test',
+								update_time: null,
+								name: null,
+								deleted: false
+							}
+						]
+					})
+				});
+
+			} else {
+
+				return new Promise((resolve, reject) => {
+					reject('not expected');
+				});
+			}
+		}
+	};
+
+	const done = assert.async();
+	const data = DataDb(config, true);
+
+	//ruleset_id, rulesetOverrideFile, ruleLoader, version, dbId, group, admin
+	data.retrieveRuleset(ruleset_filename, undefined, ruleLoader, undefined, undefined, undefined, undefined).then((ruleset) => {
+		assert.ok(ruleset, "Expect to have a ruleset");
+		assert.equal(ruleset.canedit, false, "Expect not to be able to edit");
+		assert.equal(ruleset.import.config.accessKey, '********', 'Private config should be blanked out');
+		done();
+	}, (e) => {
+		assert.ok(false, 'Got reject: ' + e);
+		done();
+	}).catch((e) => {
+		assert.ok(false, 'Got exception: ' + e);
+		done();
+	});
+
+});
+
+QUnit.test( "retrieveRuleSet: can see protected properties", function(assert){
+
+	const ruleset_filename = 'test';
+
+	const config = {
+		query: (text, values) => {
+			if(text.startsWith('SELECT')) {
+				//the get current row test
+				return new Promise((resolve) => {
+					resolve({
+						rows: [
+							{
+								id: 0,
+								version: 0,
+								ruleset_id: ruleset_filename,
+								rules: {
+									import: {
+										filename: 'S3Import',
+										config: {
+											accessKey: '12345'
+										}
+									}
+								},
+								owner_user: null,
+								owner_group: 'test',
+								update_time: null,
+								name: null,
+								deleted: false
+							}
+						]
+					})
+				});
+
+			} else {
+
+				return new Promise((resolve, reject) => {
+					reject('not expected');
+				});
+			}
+		}
+	};
+
+	const done = assert.async();
+	const data = DataDb(config, true);
+
+	//ruleset_id, rulesetOverrideFile, ruleLoader, version, dbId, group, admin
+	data.retrieveRuleset(ruleset_filename, undefined, ruleLoader, undefined, undefined, 'test', undefined).then((ruleset) => {
+		assert.ok(ruleset, "Expect to have a ruleset");
+		assert.equal(ruleset.canedit, true, "Expect to be able to edit");
+		assert.equal(ruleset.import.config.accessKey, '12345', 'Private config should be visible');
+		done();
+	}, (e) => {
+		assert.ok(false, 'Got reject: ' + e);
+		done();
+	}).catch((e) => {
+		assert.ok(false, 'Got exception: ' + e);
 		done();
 	});
 

--- a/src/validator/tests/unit/test-dataDb-rule.js
+++ b/src/validator/tests/unit/test-dataDb-rule.js
@@ -26,12 +26,12 @@ const RuleLoader = require('../../../common/ruleLoader');
 
 const ruleLoader = new RuleLoader();
 
-QUnit.module("DataDb - Ruleset");
+QUnit.module("DataDb - Rule");
 
-QUnit.test( "saveRuleSet: Successful", function(assert){
+QUnit.test( "saveRule: Successful", function(assert){
 
-	const ruleset = {
-		filename: 'test',
+	const rule = {
+		rule_id: 'test',
 		version: 0
 	};
 
@@ -45,12 +45,15 @@ QUnit.test( "saveRuleSet: Successful", function(assert){
 							{
 								id: 0,
 								version: 0,
-								ruleset_id: ruleset.filename,
-								rules: null,
+								rule_id: rule.rule_id,
+								description: null,
+								group: null,
+								base: null,
+								type: null,
+								config: null,
 								owner_user: null,
 								owner_group: null,
 								update_time: null,
-								name: null,
 								deleted: false
 							}
 						]
@@ -77,8 +80,8 @@ QUnit.test( "saveRuleSet: Successful", function(assert){
 	const done = assert.async();
 	const data = DataDb(config, true);
 
-	data.saveRuleSet(ruleset).then((filename) => {
-		assert.equal(filename, ruleset.filename, "Expect filename to be the same");
+	data.saveRule(rule).then((filename) => {
+		assert.equal(filename, rule.rule_id, "Expect filename to be the same");
 		done();
 	}, (e) => {
 		assert.ok(false, 'Got reject');
@@ -90,10 +93,10 @@ QUnit.test( "saveRuleSet: Successful", function(assert){
 
 });
 
-QUnit.test( "saveRuleSet: Successful same group", function(assert){
+QUnit.test( "saveRule: Successful same group", function(assert){
 
-	const ruleset = {
-		filename: 'test',
+	const rule = {
+		rule_id: 'test',
 		version: 0
 	};
 
@@ -107,8 +110,12 @@ QUnit.test( "saveRuleSet: Successful same group", function(assert){
 							{
 								id: 0,
 								version: 0,
-								ruleset_id: ruleset.filename,
-								rules: null,
+								rule_id: rule.rule_id,
+								description: null,
+								group: null,
+								base: null,
+								type: null,
+								config: null,
 								owner_user: null,
 								owner_group: 'some group',
 								update_time: null,
@@ -139,8 +146,8 @@ QUnit.test( "saveRuleSet: Successful same group", function(assert){
 	const done = assert.async();
 	const data = DataDb(config, true);
 
-	data.saveRuleSet(ruleset, 'user', 'some group').then((filename) => {
-		assert.equal(filename, ruleset.filename, "Expect filename to be the same");
+	data.saveRule(rule, 'user', 'some group').then((filename) => {
+		assert.equal(filename, rule.rule_id, "Expect filename to be the same");
 		done();
 	}, (e) => {
 		assert.ok(false, 'Got reject');
@@ -152,10 +159,10 @@ QUnit.test( "saveRuleSet: Successful same group", function(assert){
 
 });
 
-QUnit.test( "saveRuleSet: Wrong group", function(assert){
+QUnit.test( "saveRule: Wrong group", function(assert){
 
-	const ruleset = {
-		filename: 'test',
+	const rule = {
+		rule_id: 'test',
 		version: 0
 	};
 
@@ -169,8 +176,12 @@ QUnit.test( "saveRuleSet: Wrong group", function(assert){
 							{
 								id: 0,
 								version: 0,
-								ruleset_id: ruleset.filename,
-								rules: null,
+								rule_id: rule.rule_id,
+								description: null,
+								group: null,
+								base: null,
+								type: null,
+								config: null,
 								owner_user: null,
 								owner_group: 'some group',
 								update_time: null,
@@ -199,7 +210,7 @@ QUnit.test( "saveRuleSet: Wrong group", function(assert){
 	const done = assert.async();
 	const data = DataDb(config, true);
 
-	data.saveRuleSet(ruleset, 'user', 'other group', false).then((filename) => {
+	data.saveRule(rule, 'user', 'other group', false).then((filename) => {
 		assert.ok(false, "Expected save to fail");
 		done();
 	}, (e) => {
@@ -212,10 +223,10 @@ QUnit.test( "saveRuleSet: Wrong group", function(assert){
 
 });
 
-QUnit.test( "saveRuleSet: admin and other group", function(assert){
+QUnit.test( "saveRule: admin and other group", function(assert){
 
-	const ruleset = {
-		filename: 'test',
+	const rule = {
+		rule_id: 'test',
 		version: 0
 	};
 
@@ -229,8 +240,12 @@ QUnit.test( "saveRuleSet: admin and other group", function(assert){
 							{
 								id: 0,
 								version: 0,
-								ruleset_id: ruleset.filename,
-								rules: null,
+								rule_id: rule.rule_id,
+								description: null,
+								group: null,
+								base: null,
+								type: null,
+								config: null,
 								owner_user: null,
 								owner_group: 'some group',
 								update_time: null,
@@ -259,7 +274,7 @@ QUnit.test( "saveRuleSet: admin and other group", function(assert){
 	const done = assert.async();
 	const data = DataDb(config, true);
 
-	data.saveRuleSet(ruleset, 'user', 'other group', true).then((filename) => {
+	data.saveRule(rule, 'user', 'other group', true).then((filename) => {
 		assert.ok(true, "Expected save to succeed");
 		done();
 	}, (e) => {
@@ -272,10 +287,10 @@ QUnit.test( "saveRuleSet: admin and other group", function(assert){
 
 });
 
-QUnit.test( "saveRuleSet: Wrong version", function(assert){
+QUnit.test( "saveRule: Wrong version", function(assert){
 
-	const ruleset = {
-		filename: 'test',
+	const rule = {
+		rule_id: 'test',
 		version: 0
 	};
 
@@ -289,8 +304,12 @@ QUnit.test( "saveRuleSet: Wrong version", function(assert){
 							{
 								id: 0,
 								version: 1,
-								ruleset_id: ruleset.filename,
-								rules: null,
+								rule_id: rule.rule_id,
+								description: null,
+								group: null,
+								base: null,
+								type: null,
+								config: null,
 								owner_user: null,
 								owner_group: 'some group',
 								update_time: null,
@@ -319,7 +338,7 @@ QUnit.test( "saveRuleSet: Wrong version", function(assert){
 	const done = assert.async();
 	const data = DataDb(config, true);
 
-	data.saveRuleSet(ruleset, 'user', 'some group', false).then((filename) => {
+	data.saveRule(rule, 'user', 'some group', false).then((filename) => {
 		assert.ok(false, "Expected save to fail");
 		done();
 	}, (e) => {
@@ -332,10 +351,10 @@ QUnit.test( "saveRuleSet: Wrong version", function(assert){
 
 });
 
-QUnit.test( "saveRuleSet: Successful same name as deleted", function(assert){
+QUnit.test( "saveRule: Successful same name as deleted", function(assert){
 
-	const ruleset = {
-		filename: 'test',
+	const rule = {
+		rule_id: 'test',
 		version: 0
 	};
 
@@ -349,8 +368,12 @@ QUnit.test( "saveRuleSet: Successful same name as deleted", function(assert){
 							{
 								id: 0,
 								version: 0,
-								ruleset_id: ruleset.filename,
-								rules: null,
+								rule_id: rule.rule_id,
+								description: null,
+								group: null,
+								base: null,
+								type: null,
+								config: null,
 								owner_user: null,
 								owner_group: 'some group',
 								update_time: null,
@@ -381,8 +404,8 @@ QUnit.test( "saveRuleSet: Successful same name as deleted", function(assert){
 	const done = assert.async();
 	const data = DataDb(config, true);
 
-	data.saveRuleSet(ruleset, 'user', 'other group').then((filename) => {
-		assert.equal(filename, ruleset.filename, "Expect filename to be the same");
+	data.saveRule(rule, 'user', 'other group').then((filename) => {
+		assert.equal(filename, rule.rule_id, "Expect filename to be the same");
 		done();
 	}, (e) => {
 		assert.ok(false, 'Got reject');
@@ -394,10 +417,10 @@ QUnit.test( "saveRuleSet: Successful same name as deleted", function(assert){
 
 });
 
-QUnit.test( "deleteRuleSet: Successful", function(assert){
+QUnit.test( "deleteRule: Successful", function(assert){
 
-	const ruleset = {
-		filename: 'test',
+	const rule = {
+		rule_id: 'test',
 		version: 0
 	};
 
@@ -411,8 +434,12 @@ QUnit.test( "deleteRuleSet: Successful", function(assert){
 							{
 								id: 0,
 								version: 0,
-								ruleset_id: ruleset.filename,
-								rules: null,
+								rule_id: rule.rule_id,
+								description: null,
+								group: null,
+								base: null,
+								type: null,
+								config: null,
 								owner_user: null,
 								owner_group: null,
 								update_time: null,
@@ -435,8 +462,8 @@ QUnit.test( "deleteRuleSet: Successful", function(assert){
 	const done = assert.async();
 	const data = DataDb(config, true);
 
-	data.deleteRuleSet(ruleset).then((filename) => {
-		assert.equal(filename, ruleset.filename, "Expect filename to be the same");
+	data.deleteRule(rule).then((filename) => {
+		assert.equal(filename, rule.rule_id, "Expect filename to be the same");
 		done();
 	}, (e) => {
 		assert.ok(false, 'Got reject');
@@ -448,10 +475,10 @@ QUnit.test( "deleteRuleSet: Successful", function(assert){
 
 });
 
-QUnit.test( "deleteRuleSet: Successful same group", function(assert){
+QUnit.test( "deleteRule: Successful same group", function(assert){
 
-	const ruleset = {
-		filename: 'test',
+	const rule = {
+		rule_id: 'test',
 		version: 0
 	};
 
@@ -465,8 +492,12 @@ QUnit.test( "deleteRuleSet: Successful same group", function(assert){
 							{
 								id: 0,
 								version: 0,
-								ruleset_id: ruleset.filename,
-								rules: null,
+								rule_id: rule.rule_id,
+								description: null,
+								group: null,
+								base: null,
+								type: null,
+								config: null,
 								owner_user: null,
 								owner_group: 'some group',
 								update_time: null,
@@ -489,8 +520,8 @@ QUnit.test( "deleteRuleSet: Successful same group", function(assert){
 	const done = assert.async();
 	const data = DataDb(config, true);
 
-	data.deleteRuleSet(ruleset, 'user', 'some group').then((filename) => {
-		assert.equal(filename, ruleset.filename, "Expect filename to be the same");
+	data.deleteRule(rule, 'user', 'some group').then((filename) => {
+		assert.equal(filename, rule.rule_id, "Expect filename to be the same");
 		done();
 	}, (e) => {
 		assert.ok(false, 'Got reject');
@@ -502,10 +533,10 @@ QUnit.test( "deleteRuleSet: Successful same group", function(assert){
 
 });
 
-QUnit.test( "deleteRuleSet: Wrong version", function(assert){
+QUnit.test( "deleteRule: Wrong version", function(assert){
 
-	const ruleset = {
-		filename: 'test',
+	const rule = {
+		rule_id: 'test',
 		version: 0
 	};
 
@@ -519,8 +550,12 @@ QUnit.test( "deleteRuleSet: Wrong version", function(assert){
 							{
 								id: 0,
 								version: 1,
-								ruleset_id: ruleset.filename,
-								rules: null,
+								rule_id: rule.rule_id,
+								description: null,
+								group: null,
+								base: null,
+								type: null,
+								config: null,
 								owner_user: null,
 								owner_group: 'some group',
 								update_time: null,
@@ -543,7 +578,7 @@ QUnit.test( "deleteRuleSet: Wrong version", function(assert){
 	const done = assert.async();
 	const data = DataDb(config, true);
 
-	data.deleteRuleSet(ruleset).then((filename) => {
+	data.deleteRule(rule).then((filename) => {
 		assert.ok(false, "Expected delete to fail");
 		done();
 	}, (e) => {
@@ -556,10 +591,10 @@ QUnit.test( "deleteRuleSet: Wrong version", function(assert){
 
 });
 
-QUnit.test( "deleteRuleSet: Wrong group", function(assert){
+QUnit.test( "deleteRule: Wrong group", function(assert){
 
-	const ruleset = {
-		filename: 'test',
+	const rule = {
+		rule_id: 'test',
 		version: 0
 	};
 
@@ -573,8 +608,12 @@ QUnit.test( "deleteRuleSet: Wrong group", function(assert){
 							{
 								id: 0,
 								version: 1,
-								ruleset_id: ruleset.filename,
-								rules: null,
+								rule_id: rule.rule_id,
+								description: null,
+								group: null,
+								base: null,
+								type: null,
+								config: null,
 								owner_user: null,
 								owner_group: 'some group',
 								update_time: null,
@@ -597,7 +636,7 @@ QUnit.test( "deleteRuleSet: Wrong group", function(assert){
 	const done = assert.async();
 	const data = DataDb(config, true);
 
-	data.deleteRuleSet(ruleset, 'user', 'other group').then((filename) => {
+	data.deleteRule(rule, 'user', 'other group').then((filename) => {
 		assert.ok(false, "Expected delete to fail");
 		done();
 	}, (e) => {
@@ -610,10 +649,10 @@ QUnit.test( "deleteRuleSet: Wrong group", function(assert){
 
 });
 
-QUnit.test( "deleteRuleSet: admin override wrong group", function(assert){
+QUnit.test( "deleteRule: admin override wrong group", function(assert){
 
-	const ruleset = {
-		filename: 'test',
+	const rule = {
+		rule_id: 'test',
 		version: 0
 	};
 
@@ -627,8 +666,12 @@ QUnit.test( "deleteRuleSet: admin override wrong group", function(assert){
 							{
 								id: 0,
 								version: 0,
-								ruleset_id: ruleset.filename,
-								rules: null,
+								rule_id: rule.rule_id,
+								description: null,
+								group: null,
+								base: null,
+								type: null,
+								config: null,
 								owner_user: null,
 								owner_group: 'some group',
 								update_time: null,
@@ -651,8 +694,8 @@ QUnit.test( "deleteRuleSet: admin override wrong group", function(assert){
 	const done = assert.async();
 	const data = DataDb(config, true);
 
-	data.deleteRuleSet(ruleset, 'user', 'other group', true).then((filename) => {
-		assert.equal(filename, ruleset.filename, "Expect filename to be the same");
+	data.deleteRule(rule, 'user', 'other group', true).then((filename) => {
+		assert.equal(filename, rule.rule_id, "Expect filename to be the same");
 		done();
 	}, (e) => {
 		assert.ok(false, 'Got reject');
@@ -665,9 +708,9 @@ QUnit.test( "deleteRuleSet: admin override wrong group", function(assert){
 });
 
 
-QUnit.test( "retrieveRuleSet: can edit with no owner", function(assert){
+QUnit.test( "retrieveRule: can edit with no owner", function(assert){
 
-	const ruleset_filename = 'test';
+	const rule_id = 'test';
 
 	const config = {
 		query: (text, values) => {
@@ -679,8 +722,12 @@ QUnit.test( "retrieveRuleSet: can edit with no owner", function(assert){
 							{
 								id: 0,
 								version: 0,
-								ruleset_id: ruleset_filename,
-								rules: {},
+								rule_id: rule_id,
+								description: null,
+								group: null,
+								base: null,
+								type: null,
+								config: null,
 								owner_user: null,
 								owner_group: null,
 								update_time: null,
@@ -703,10 +750,10 @@ QUnit.test( "retrieveRuleSet: can edit with no owner", function(assert){
 	const done = assert.async();
 	const data = DataDb(config, true);
 
-	//ruleset_id, rulesetOverrideFile, ruleLoader, version, dbId, group, admin
-	data.retrieveRuleset(ruleset_filename, undefined, undefined, undefined, undefined, undefined, undefined).then((ruleset) => {
-		assert.ok(ruleset, "Expect to have a ruleset");
-		assert.equal(ruleset.canedit, true, "Expect to be able to edit");
+	//rule_id, version, dbId, group, admin, rulesLoader
+	data.retrieveRule(rule_id, undefined, undefined, undefined, undefined, undefined).then((rule) => {
+		assert.ok(rule, "Expect to have a rule");
+		assert.equal(rule.canedit, true, "Expect to be able to edit");
 		done();
 	}, (e) => {
 		assert.ok(false, 'Got reject: ' + e);
@@ -718,9 +765,9 @@ QUnit.test( "retrieveRuleSet: can edit with no owner", function(assert){
 
 });
 
-QUnit.test( "retrieveRuleSet: can edit with same group", function(assert){
+QUnit.test( "retrieveRule: can edit with same group", function(assert){
 
-	const ruleset_filename = 'test';
+	const rule_id = 'test';
 
 	const config = {
 		query: (text, values) => {
@@ -732,8 +779,12 @@ QUnit.test( "retrieveRuleSet: can edit with same group", function(assert){
 							{
 								id: 0,
 								version: 0,
-								ruleset_id: ruleset_filename,
-								rules: {},
+								rule_id: rule_id,
+								description: null,
+								group: null,
+								base: null,
+								type: null,
+								config: null,
 								owner_user: null,
 								owner_group: 'test',
 								update_time: null,
@@ -756,10 +807,10 @@ QUnit.test( "retrieveRuleSet: can edit with same group", function(assert){
 	const done = assert.async();
 	const data = DataDb(config, true);
 
-	//ruleset_id, rulesetOverrideFile, ruleLoader, version, dbId, group, admin
-	data.retrieveRuleset(ruleset_filename, undefined, undefined, undefined, undefined, 'test', undefined).then((ruleset) => {
-		assert.ok(ruleset, "Expect to have a ruleset");
-		assert.equal(ruleset.canedit, true, "Expect to be able to edit");
+	//rule_id, version, dbId, group, admin, rulesLoader
+	data.retrieveRule(rule_id, undefined, undefined, 'test', undefined, undefined).then((rule) => {
+		assert.ok(rule, "Expect to have a rule");
+		assert.equal(rule.canedit, true, "Expect to be able to edit");
 		done();
 	}, (e) => {
 		assert.ok(false, 'Got reject: ' + e);
@@ -771,9 +822,9 @@ QUnit.test( "retrieveRuleSet: can edit with same group", function(assert){
 
 });
 
-QUnit.test( "retrieveRuleSet: can edit as admin", function(assert){
+QUnit.test( "retrieveRule: can edit as admin", function(assert){
 
-	const ruleset_filename = 'test';
+	const rule_id = 'test';
 
 	const config = {
 		query: (text, values) => {
@@ -785,8 +836,12 @@ QUnit.test( "retrieveRuleSet: can edit as admin", function(assert){
 							{
 								id: 0,
 								version: 0,
-								ruleset_id: ruleset_filename,
-								rules: {},
+								rule_id: rule_id,
+								description: null,
+								group: null,
+								base: null,
+								type: null,
+								config: null,
 								owner_user: null,
 								owner_group: 'test',
 								update_time: null,
@@ -809,10 +864,10 @@ QUnit.test( "retrieveRuleSet: can edit as admin", function(assert){
 	const done = assert.async();
 	const data = DataDb(config, true);
 
-	//ruleset_id, rulesetOverrideFile, ruleLoader, version, dbId, group, admin
-	data.retrieveRuleset(ruleset_filename, undefined, undefined, undefined, undefined, 'another group', true).then((ruleset) => {
-		assert.ok(ruleset, "Expect to have a ruleset");
-		assert.equal(ruleset.canedit, true, "Expect to be able to edit");
+	//rule_id, version, dbId, group, admin, rulesLoader
+	data.retrieveRule(rule_id, undefined, undefined, 'another group', true, undefined).then((rule) => {
+		assert.ok(rule, "Expect to have a rule");
+		assert.equal(rule.canedit, true, "Expect to be able to edit");
 		done();
 	}, (e) => {
 		assert.ok(false, 'Got reject: ' + e);
@@ -824,9 +879,9 @@ QUnit.test( "retrieveRuleSet: can edit as admin", function(assert){
 
 });
 
-QUnit.test( "retrieveRuleSet: can't edit as different group", function(assert){
+QUnit.test( "retrieveRule: can't edit as different group", function(assert){
 
-	const ruleset_filename = 'test';
+	const rule_id = 'test';
 
 	const config = {
 		query: (text, values) => {
@@ -838,8 +893,12 @@ QUnit.test( "retrieveRuleSet: can't edit as different group", function(assert){
 							{
 								id: 0,
 								version: 0,
-								ruleset_id: ruleset_filename,
-								rules: {},
+								rule_id: rule_id,
+								description: null,
+								group: null,
+								base: null,
+								type: null,
+								config: null,
 								owner_user: null,
 								owner_group: 'test',
 								update_time: null,
@@ -862,10 +921,10 @@ QUnit.test( "retrieveRuleSet: can't edit as different group", function(assert){
 	const done = assert.async();
 	const data = DataDb(config, true);
 
-	//ruleset_id, rulesetOverrideFile, ruleLoader, version, dbId, group, admin
-	data.retrieveRuleset(ruleset_filename, undefined, undefined, undefined, undefined, 'another group', undefined).then((ruleset) => {
-		assert.ok(ruleset, "Expect to have a ruleset");
-		assert.equal(ruleset.canedit, false, "Expect not to be able to edit");
+	//rule_id, version, dbId, group, admin, rulesLoader
+	data.retrieveRule(rule_id, undefined, undefined, 'another group', undefined, undefined).then((rule) => {
+		assert.ok(rule, "Expect to have a rule");
+		assert.equal(rule.canedit, false, "Expect not to be able to edit");
 		done();
 	}, (e) => {
 		assert.ok(false, 'Got reject: ' + e);
@@ -877,9 +936,9 @@ QUnit.test( "retrieveRuleSet: can't edit as different group", function(assert){
 
 });
 
-QUnit.test( "retrieveRuleSet: can't edit with no group", function(assert){
+QUnit.test( "retrieveRule: can't edit with no group", function(assert){
 
-	const ruleset_filename = 'test';
+	const rule_id = 'test';
 
 	const config = {
 		query: (text, values) => {
@@ -891,8 +950,12 @@ QUnit.test( "retrieveRuleSet: can't edit with no group", function(assert){
 							{
 								id: 0,
 								version: 0,
-								ruleset_id: ruleset_filename,
-								rules: {},
+								rule_id: rule_id,
+								description: null,
+								group: null,
+								base: null,
+								type: null,
+								config: null,
 								owner_user: null,
 								owner_group: 'test',
 								update_time: null,
@@ -915,10 +978,10 @@ QUnit.test( "retrieveRuleSet: can't edit with no group", function(assert){
 	const done = assert.async();
 	const data = DataDb(config, true);
 
-	//ruleset_id, rulesetOverrideFile, ruleLoader, version, dbId, group, admin
-	data.retrieveRuleset(ruleset_filename, undefined, undefined, undefined, undefined, undefined, undefined).then((ruleset) => {
-		assert.ok(ruleset, "Expect to have a ruleset");
-		assert.equal(ruleset.canedit, false, "Expect not to be able to edit");
+	//rule_id, version, dbId, group, admin, rulesLoader
+	data.retrieveRule(rule_id, undefined, undefined, undefined, undefined, undefined).then((rule) => {
+		assert.ok(rule, "Expect to have a rule");
+		assert.equal(rule.canedit, false, "Expect not to be able to edit");
 		done();
 	}, (e) => {
 		assert.ok(false, 'Got reject: ' + e);
@@ -930,9 +993,9 @@ QUnit.test( "retrieveRuleSet: can't edit with no group", function(assert){
 
 });
 
-QUnit.test( "retrieveRuleSet: can't see protected properties", function(assert){
+QUnit.test( "retrieveRule: can't see protected properties", function(assert){
 
-	const ruleset_filename = 'test';
+	const rule_id = 'test';
 
 	const config = {
 		query: (text, values) => {
@@ -944,14 +1007,13 @@ QUnit.test( "retrieveRuleSet: can't see protected properties", function(assert){
 							{
 								id: 0,
 								version: 0,
-								ruleset_id: ruleset_filename,
-								rules: {
-									import: {
-										filename: 'S3Import',
-										config: {
-											accessKey: '12345'
-										}
-									}
+								rule_id: rule_id,
+								description: null,
+								group: null,
+								base: 'S3Import',
+								type: 'source',
+								config: {
+									accessKey: '12345'
 								},
 								owner_user: null,
 								owner_group: 'test',
@@ -975,11 +1037,11 @@ QUnit.test( "retrieveRuleSet: can't see protected properties", function(assert){
 	const done = assert.async();
 	const data = DataDb(config, true);
 
-	//ruleset_id, rulesetOverrideFile, ruleLoader, version, dbId, group, admin
-	data.retrieveRuleset(ruleset_filename, undefined, ruleLoader, undefined, undefined, undefined, undefined).then((ruleset) => {
-		assert.ok(ruleset, "Expect to have a ruleset");
-		assert.equal(ruleset.canedit, false, "Expect not to be able to edit");
-		assert.equal(ruleset.import.config.accessKey, '********', 'Private config should be blanked out');
+	//rule_id, version, dbId, group, admin, rulesLoader
+	data.retrieveRule(rule_id, undefined, undefined, undefined, undefined, ruleLoader).then((rule) => {
+		assert.ok(rule, "Expect to have a rule");
+		assert.equal(rule.canedit, false, "Expect not to be able to edit");
+		assert.equal(rule.config.accessKey, '********', 'Private config should be blanked out');
 		done();
 	}, (e) => {
 		assert.ok(false, 'Got reject: ' + e);
@@ -991,9 +1053,9 @@ QUnit.test( "retrieveRuleSet: can't see protected properties", function(assert){
 
 });
 
-QUnit.test( "retrieveRuleSet: can see protected properties", function(assert){
+QUnit.test( "retrieveRule: can see protected properties", function(assert){
 
-	const ruleset_filename = 'test';
+	const rule_id = 'test';
 
 	const config = {
 		query: (text, values) => {
@@ -1005,14 +1067,13 @@ QUnit.test( "retrieveRuleSet: can see protected properties", function(assert){
 							{
 								id: 0,
 								version: 0,
-								ruleset_id: ruleset_filename,
-								rules: {
-									import: {
-										filename: 'S3Import',
-										config: {
-											accessKey: '12345'
-										}
-									}
+								rule_id: rule_id,
+								description: null,
+								group: null,
+								base: 'S3Import',
+								type: 'source',
+								config: {
+									accessKey: '12345'
 								},
 								owner_user: null,
 								owner_group: 'test',
@@ -1036,11 +1097,11 @@ QUnit.test( "retrieveRuleSet: can see protected properties", function(assert){
 	const done = assert.async();
 	const data = DataDb(config, true);
 
-	//ruleset_id, rulesetOverrideFile, ruleLoader, version, dbId, group, admin
-	data.retrieveRuleset(ruleset_filename, undefined, ruleLoader, undefined, undefined, 'test', undefined).then((ruleset) => {
-		assert.ok(ruleset, "Expect to have a ruleset");
-		assert.equal(ruleset.canedit, true, "Expect to be able to edit");
-		assert.equal(ruleset.import.config.accessKey, '12345', 'Private config should be visible');
+	//rule_id, version, dbId, group, admin, rulesLoader
+	data.retrieveRule(rule_id, undefined, undefined, 'test', undefined, ruleLoader).then((rule) => {
+		assert.ok(rule, "Expect to have a rule");
+		assert.equal(rule.canedit, true, "Expect to be able to edit");
+		assert.equal(rule.config.accessKey, '12345', 'Private config should be visible');
 		done();
 	}, (e) => {
 		assert.ok(false, 'Got reject: ' + e);

--- a/src/validator/tests/unit/test-dataDb-ruleset.js
+++ b/src/validator/tests/unit/test-dataDb-ruleset.js
@@ -1,0 +1,1055 @@
+const proxyquire = require('proxyquire');
+
+const DataDb = proxyquire("../../../common/dataDb", {
+	"./db" : function(config) {
+		return {
+			end: function() {},
+			query: function(text, values, callback) {
+				if(config && config.query) {
+					return config.query(text, values, callback);
+				}
+
+				if(callback) {
+					throw "No query handler";
+				}
+
+				return new Promise((resolve, reject) => {
+					reject('no query handler');
+				})
+
+
+			}
+		}
+	}
+});
+const RuleLoader = require('../../../common/ruleLoader');
+
+const ruleLoader = new RuleLoader();
+
+QUnit.module("DataDb - Ruleset");
+
+QUnit.test( "saveRuleSet: Successful", function(assert){
+
+	const ruleset = {
+		filename: 'test',
+		version: 0
+	};
+
+	const config = {
+		query: (text, values) => {
+			if(text.startsWith('SELECT')) {
+				//the get current row test
+				return new Promise((resolve) => {
+					resolve({
+						rows: [
+							{
+								id: 0,
+								version: 0,
+								ruleset_id: ruleset.filename,
+								rules: null,
+								owner_user: null,
+								owner_group: null,
+								update_time: null,
+								name: null,
+								deleted: false
+							}
+						]
+					})
+				});
+
+			} else {
+				//the update call
+				assert.equal(values[2], 1, "Version should be 1");
+
+				return new Promise((resolve) => {
+					resolve({
+						rows: [
+							{
+								id: 1
+							}
+						]
+					})
+				});
+			}
+		}
+	};
+
+	const done = assert.async();
+	const data = DataDb(config, true);
+
+	data.saveRuleSet(ruleset).then((filename) => {
+		assert.equal(filename, ruleset.filename, "Expect filename to be the same");
+		done();
+	}, (e) => {
+		assert.ok(false, 'Got reject');
+		done();
+	}).catch((e) => {
+		assert.ok(false, 'Got exception');
+		done();
+	});
+
+});
+
+QUnit.test( "saveRuleSet: Successful same group", function(assert){
+
+	const ruleset = {
+		filename: 'test',
+		version: 0
+	};
+
+	const config = {
+		query: (text, values) => {
+			if(text.startsWith('SELECT')) {
+				//the get current row test
+				return new Promise((resolve) => {
+					resolve({
+						rows: [
+							{
+								id: 0,
+								version: 0,
+								ruleset_id: ruleset.filename,
+								rules: null,
+								owner_user: null,
+								owner_group: 'some group',
+								update_time: null,
+								name: null,
+								deleted: false
+							}
+						]
+					})
+				});
+
+			} else {
+				//the update call
+				assert.equal(values[2], 1, "Version should be 1");
+
+				return new Promise((resolve) => {
+					resolve({
+						rows: [
+							{
+								id: 1
+							}
+						]
+					})
+				});
+			}
+		}
+	};
+
+	const done = assert.async();
+	const data = DataDb(config, true);
+
+	data.saveRuleSet(ruleset, 'user', 'some group').then((filename) => {
+		assert.equal(filename, ruleset.filename, "Expect filename to be the same");
+		done();
+	}, (e) => {
+		assert.ok(false, 'Got reject');
+		done();
+	}).catch((e) => {
+		assert.ok(false, 'Got exception');
+		done();
+	});
+
+});
+
+QUnit.test( "saveRuleSet: Wrong group", function(assert){
+
+	const ruleset = {
+		filename: 'test',
+		version: 0
+	};
+
+	const config = {
+		query: (text, values) => {
+			if(text.startsWith('SELECT')) {
+				//the get current row test
+				return new Promise((resolve) => {
+					resolve({
+						rows: [
+							{
+								id: 0,
+								version: 0,
+								ruleset_id: ruleset.filename,
+								rules: null,
+								owner_user: null,
+								owner_group: 'some group',
+								update_time: null,
+								name: null,
+								deleted: false
+							}
+						]
+					})
+				});
+
+			} else {
+				//the update call
+				return new Promise((resolve) => {
+					resolve({
+						rows: [
+							{
+								id: 1
+							}
+						]
+					})
+				});
+			}
+		}
+	};
+
+	const done = assert.async();
+	const data = DataDb(config, true);
+
+	data.saveRuleSet(ruleset, 'user', 'other group', false).then((filename) => {
+		assert.ok(false, "Expected save to fail");
+		done();
+	}, (e) => {
+		assert.ok(true, 'Expected rejection');
+		done();
+	}).catch((e) => {
+		assert.ok(false, 'Got exception');
+		done();
+	});
+
+});
+
+QUnit.test( "saveRuleSet: admin and other group", function(assert){
+
+	const ruleset = {
+		filename: 'test',
+		version: 0
+	};
+
+	const config = {
+		query: (text, values) => {
+			if(text.startsWith('SELECT')) {
+				//the get current row test
+				return new Promise((resolve) => {
+					resolve({
+						rows: [
+							{
+								id: 0,
+								version: 0,
+								ruleset_id: ruleset.filename,
+								rules: null,
+								owner_user: null,
+								owner_group: 'some group',
+								update_time: null,
+								name: null,
+								deleted: false
+							}
+						]
+					})
+				});
+
+			} else {
+				//the update call
+				return new Promise((resolve) => {
+					resolve({
+						rows: [
+							{
+								id: 1
+							}
+						]
+					})
+				});
+			}
+		}
+	};
+
+	const done = assert.async();
+	const data = DataDb(config, true);
+
+	data.saveRuleSet(ruleset, 'user', 'other group', true).then((filename) => {
+		assert.ok(true, "Expected save to succeed");
+		done();
+	}, (e) => {
+		assert.ok(false, 'Expected no rejection');
+		done();
+	}).catch((e) => {
+		assert.ok(false, 'Got exception');
+		done();
+	});
+
+});
+
+QUnit.test( "saveRuleSet: Wrong version", function(assert){
+
+	const ruleset = {
+		filename: 'test',
+		version: 0
+	};
+
+	const config = {
+		query: (text, values) => {
+			if(text.startsWith('SELECT')) {
+				//the get current row test
+				return new Promise((resolve) => {
+					resolve({
+						rows: [
+							{
+								id: 0,
+								version: 1,
+								ruleset_id: ruleset.filename,
+								rules: null,
+								owner_user: null,
+								owner_group: 'some group',
+								update_time: null,
+								name: null,
+								deleted: false
+							}
+						]
+					})
+				});
+
+			} else {
+				//the update call
+				return new Promise((resolve) => {
+					resolve({
+						rows: [
+							{
+								id: 1
+							}
+						]
+					})
+				});
+			}
+		}
+	};
+
+	const done = assert.async();
+	const data = DataDb(config, true);
+
+	data.saveRuleSet(ruleset, 'user', 'some group', false).then((filename) => {
+		assert.ok(false, "Expected save to fail");
+		done();
+	}, (e) => {
+		assert.ok(true, 'Expected rejection');
+		done();
+	}).catch((e) => {
+		assert.ok(false, 'Got exception');
+		done();
+	});
+
+});
+
+QUnit.test( "saveRuleSet: Successful same name as deleted", function(assert){
+
+	const ruleset = {
+		filename: 'test',
+		version: 0
+	};
+
+	const config = {
+		query: (text, values) => {
+			if(text.startsWith('SELECT')) {
+				//the get current row test
+				return new Promise((resolve) => {
+					resolve({
+						rows: [
+							{
+								id: 0,
+								version: 0,
+								ruleset_id: ruleset.filename,
+								rules: null,
+								owner_user: null,
+								owner_group: 'some group',
+								update_time: null,
+								name: null,
+								deleted: true
+							}
+						]
+					})
+				});
+
+			} else {
+				//the update call
+				assert.equal(values[2], 1, "Version should be 1");
+
+				return new Promise((resolve) => {
+					resolve({
+						rows: [
+							{
+								id: 1
+							}
+						]
+					})
+				});
+			}
+		}
+	};
+
+	const done = assert.async();
+	const data = DataDb(config, true);
+
+	data.saveRuleSet(ruleset, 'user', 'other group').then((filename) => {
+		assert.equal(filename, ruleset.filename, "Expect filename to be the same");
+		done();
+	}, (e) => {
+		assert.ok(false, 'Got reject');
+		done();
+	}).catch((e) => {
+		assert.ok(false, 'Got exception');
+		done();
+	});
+
+});
+
+QUnit.test( "deleteRuleSet: Successful", function(assert){
+
+	const ruleset = {
+		filename: 'test',
+		version: 0
+	};
+
+	const config = {
+		query: (text, values) => {
+			if(text.startsWith('SELECT')) {
+				//the get current row test
+				return new Promise((resolve) => {
+					resolve({
+						rows: [
+							{
+								id: 0,
+								version: 0,
+								ruleset_id: ruleset.filename,
+								rules: null,
+								owner_user: null,
+								owner_group: null,
+								update_time: null,
+								name: null,
+								deleted: false
+							}
+						]
+					})
+				});
+
+			} else {
+				//the delete call
+				return new Promise((resolve) => {
+					resolve();
+				});
+			}
+		}
+	};
+
+	const done = assert.async();
+	const data = DataDb(config, true);
+
+	data.deleteRuleSet(ruleset).then((filename) => {
+		assert.equal(filename, ruleset.filename, "Expect filename to be the same");
+		done();
+	}, (e) => {
+		assert.ok(false, 'Got reject');
+		done();
+	}).catch((e) => {
+		assert.ok(false, 'Got exception');
+		done();
+	});
+
+});
+
+QUnit.test( "deleteRuleSet: Successful same group", function(assert){
+
+	const ruleset = {
+		filename: 'test',
+		version: 0
+	};
+
+	const config = {
+		query: (text, values) => {
+			if(text.startsWith('SELECT')) {
+				//the get current row test
+				return new Promise((resolve) => {
+					resolve({
+						rows: [
+							{
+								id: 0,
+								version: 0,
+								ruleset_id: ruleset.filename,
+								rules: null,
+								owner_user: null,
+								owner_group: 'some group',
+								update_time: null,
+								name: null,
+								deleted: false
+							}
+						]
+					})
+				});
+
+			} else {
+				//the delete call
+				return new Promise((resolve) => {
+					resolve();
+				});
+			}
+		}
+	};
+
+	const done = assert.async();
+	const data = DataDb(config, true);
+
+	data.deleteRuleSet(ruleset, 'user', 'some group').then((filename) => {
+		assert.equal(filename, ruleset.filename, "Expect filename to be the same");
+		done();
+	}, (e) => {
+		assert.ok(false, 'Got reject');
+		done();
+	}).catch((e) => {
+		assert.ok(false, 'Got exception');
+		done();
+	});
+
+});
+
+QUnit.test( "deleteRuleSet: Wrong version", function(assert){
+
+	const ruleset = {
+		filename: 'test',
+		version: 0
+	};
+
+	const config = {
+		query: (text, values) => {
+			if(text.startsWith('SELECT')) {
+				//the get current row test
+				return new Promise((resolve) => {
+					resolve({
+						rows: [
+							{
+								id: 0,
+								version: 1,
+								ruleset_id: ruleset.filename,
+								rules: null,
+								owner_user: null,
+								owner_group: 'some group',
+								update_time: null,
+								name: null,
+								deleted: false
+							}
+						]
+					})
+				});
+
+			} else {
+				//the delete call
+				return new Promise((resolve) => {
+					resolve();
+				});
+			}
+		}
+	};
+
+	const done = assert.async();
+	const data = DataDb(config, true);
+
+	data.deleteRuleSet(ruleset).then((filename) => {
+		assert.ok(false, "Expected delete to fail");
+		done();
+	}, (e) => {
+		assert.ok(true, 'Expected rejection');
+		done();
+	}).catch((e) => {
+		assert.ok(false, 'Got exception');
+		done();
+	});
+
+});
+
+QUnit.test( "deleteRuleSet: Wrong group", function(assert){
+
+	const ruleset = {
+		filename: 'test',
+		version: 0
+	};
+
+	const config = {
+		query: (text, values) => {
+			if(text.startsWith('SELECT')) {
+				//the get current row test
+				return new Promise((resolve) => {
+					resolve({
+						rows: [
+							{
+								id: 0,
+								version: 1,
+								ruleset_id: ruleset.filename,
+								rules: null,
+								owner_user: null,
+								owner_group: 'some group',
+								update_time: null,
+								name: null,
+								deleted: false
+							}
+						]
+					})
+				});
+
+			} else {
+				//the delete call
+				return new Promise((resolve) => {
+					resolve();
+				});
+			}
+		}
+	};
+
+	const done = assert.async();
+	const data = DataDb(config, true);
+
+	data.deleteRuleSet(ruleset, 'user', 'other group').then((filename) => {
+		assert.ok(false, "Expected delete to fail");
+		done();
+	}, (e) => {
+		assert.ok(true, 'Expected rejection');
+		done();
+	}).catch((e) => {
+		assert.ok(false, 'Got exception');
+		done();
+	});
+
+});
+
+QUnit.test( "deleteRuleSet: admin override wrong group", function(assert){
+
+	const ruleset = {
+		filename: 'test',
+		version: 0
+	};
+
+	const config = {
+		query: (text, values) => {
+			if(text.startsWith('SELECT')) {
+				//the get current row test
+				return new Promise((resolve) => {
+					resolve({
+						rows: [
+							{
+								id: 0,
+								version: 0,
+								ruleset_id: ruleset.filename,
+								rules: null,
+								owner_user: null,
+								owner_group: 'some group',
+								update_time: null,
+								name: null,
+								deleted: false
+							}
+						]
+					})
+				});
+
+			} else {
+				//the delete call
+				return new Promise((resolve) => {
+					resolve();
+				});
+			}
+		}
+	};
+
+	const done = assert.async();
+	const data = DataDb(config, true);
+
+	data.deleteRuleSet(ruleset, 'user', 'other group', true).then((filename) => {
+		assert.equal(filename, ruleset.filename, "Expect filename to be the same");
+		done();
+	}, (e) => {
+		assert.ok(false, 'Got reject');
+		done();
+	}).catch((e) => {
+		assert.ok(false, 'Got exception');
+		done();
+	});
+
+});
+
+
+QUnit.test( "retrieveRuleSet: can edit with no owner", function(assert){
+
+	const ruleset_filename = 'test';
+
+	const config = {
+		query: (text, values) => {
+			if(text.startsWith('SELECT')) {
+				//the get current row test
+				return new Promise((resolve) => {
+					resolve({
+						rows: [
+							{
+								id: 0,
+								version: 0,
+								ruleset_id: ruleset_filename,
+								rules: {},
+								owner_user: null,
+								owner_group: null,
+								update_time: null,
+								name: null,
+								deleted: false
+							}
+						]
+					})
+				});
+
+			} else {
+
+				return new Promise((resolve, reject) => {
+					reject('not expected');
+				});
+			}
+		}
+	};
+
+	const done = assert.async();
+	const data = DataDb(config, true);
+
+	//ruleset_id, rulesetOverrideFile, ruleLoader, version, dbId, group, admin
+	data.retrieveRuleset(ruleset_filename, undefined, undefined, undefined, undefined, undefined, undefined).then((ruleset) => {
+		assert.ok(ruleset, "Expect to have a ruleset");
+		assert.equal(ruleset.canedit, true, "Expect to be able to edit");
+		done();
+	}, (e) => {
+		assert.ok(false, 'Got reject: ' + e);
+		done();
+	}).catch((e) => {
+		assert.ok(false, 'Got exception: ' + e);
+		done();
+	});
+
+});
+
+QUnit.test( "retrieveRuleSet: can edit with same group", function(assert){
+
+	const ruleset_filename = 'test';
+
+	const config = {
+		query: (text, values) => {
+			if(text.startsWith('SELECT')) {
+				//the get current row test
+				return new Promise((resolve) => {
+					resolve({
+						rows: [
+							{
+								id: 0,
+								version: 0,
+								ruleset_id: ruleset_filename,
+								rules: {},
+								owner_user: null,
+								owner_group: 'test',
+								update_time: null,
+								name: null,
+								deleted: false
+							}
+						]
+					})
+				});
+
+			} else {
+
+				return new Promise((resolve, reject) => {
+					reject('not expected');
+				});
+			}
+		}
+	};
+
+	const done = assert.async();
+	const data = DataDb(config, true);
+
+	//ruleset_id, rulesetOverrideFile, ruleLoader, version, dbId, group, admin
+	data.retrieveRuleset(ruleset_filename, undefined, undefined, undefined, undefined, 'test', undefined).then((ruleset) => {
+		assert.ok(ruleset, "Expect to have a ruleset");
+		assert.equal(ruleset.canedit, true, "Expect to be able to edit");
+		done();
+	}, (e) => {
+		assert.ok(false, 'Got reject: ' + e);
+		done();
+	}).catch((e) => {
+		assert.ok(false, 'Got exception: ' + e);
+		done();
+	});
+
+});
+
+QUnit.test( "retrieveRuleSet: can edit as admin", function(assert){
+
+	const ruleset_filename = 'test';
+
+	const config = {
+		query: (text, values) => {
+			if(text.startsWith('SELECT')) {
+				//the get current row test
+				return new Promise((resolve) => {
+					resolve({
+						rows: [
+							{
+								id: 0,
+								version: 0,
+								ruleset_id: ruleset_filename,
+								rules: {},
+								owner_user: null,
+								owner_group: 'test',
+								update_time: null,
+								name: null,
+								deleted: false
+							}
+						]
+					})
+				});
+
+			} else {
+
+				return new Promise((resolve, reject) => {
+					reject('not expected');
+				});
+			}
+		}
+	};
+
+	const done = assert.async();
+	const data = DataDb(config, true);
+
+	//ruleset_id, rulesetOverrideFile, ruleLoader, version, dbId, group, admin
+	data.retrieveRuleset(ruleset_filename, undefined, undefined, undefined, undefined, 'another group', true).then((ruleset) => {
+		assert.ok(ruleset, "Expect to have a ruleset");
+		assert.equal(ruleset.canedit, true, "Expect to be able to edit");
+		done();
+	}, (e) => {
+		assert.ok(false, 'Got reject: ' + e);
+		done();
+	}).catch((e) => {
+		assert.ok(false, 'Got exception: ' + e);
+		done();
+	});
+
+});
+
+QUnit.test( "retrieveRuleSet: can't edit as different group", function(assert){
+
+	const ruleset_filename = 'test';
+
+	const config = {
+		query: (text, values) => {
+			if(text.startsWith('SELECT')) {
+				//the get current row test
+				return new Promise((resolve) => {
+					resolve({
+						rows: [
+							{
+								id: 0,
+								version: 0,
+								ruleset_id: ruleset_filename,
+								rules: {},
+								owner_user: null,
+								owner_group: 'test',
+								update_time: null,
+								name: null,
+								deleted: false
+							}
+						]
+					})
+				});
+
+			} else {
+
+				return new Promise((resolve, reject) => {
+					reject('not expected');
+				});
+			}
+		}
+	};
+
+	const done = assert.async();
+	const data = DataDb(config, true);
+
+	//ruleset_id, rulesetOverrideFile, ruleLoader, version, dbId, group, admin
+	data.retrieveRuleset(ruleset_filename, undefined, undefined, undefined, undefined, 'another group', undefined).then((ruleset) => {
+		assert.ok(ruleset, "Expect to have a ruleset");
+		assert.equal(ruleset.canedit, false, "Expect not to be able to edit");
+		done();
+	}, (e) => {
+		assert.ok(false, 'Got reject: ' + e);
+		done();
+	}).catch((e) => {
+		assert.ok(false, 'Got exception: ' + e);
+		done();
+	});
+
+});
+
+QUnit.test( "retrieveRuleSet: can't edit with no group", function(assert){
+
+	const ruleset_filename = 'test';
+
+	const config = {
+		query: (text, values) => {
+			if(text.startsWith('SELECT')) {
+				//the get current row test
+				return new Promise((resolve) => {
+					resolve({
+						rows: [
+							{
+								id: 0,
+								version: 0,
+								ruleset_id: ruleset_filename,
+								rules: {},
+								owner_user: null,
+								owner_group: 'test',
+								update_time: null,
+								name: null,
+								deleted: false
+							}
+						]
+					})
+				});
+
+			} else {
+
+				return new Promise((resolve, reject) => {
+					reject('not expected');
+				});
+			}
+		}
+	};
+
+	const done = assert.async();
+	const data = DataDb(config, true);
+
+	//ruleset_id, rulesetOverrideFile, ruleLoader, version, dbId, group, admin
+	data.retrieveRuleset(ruleset_filename, undefined, undefined, undefined, undefined, undefined, undefined).then((ruleset) => {
+		assert.ok(ruleset, "Expect to have a ruleset");
+		assert.equal(ruleset.canedit, false, "Expect not to be able to edit");
+		done();
+	}, (e) => {
+		assert.ok(false, 'Got reject: ' + e);
+		done();
+	}).catch((e) => {
+		assert.ok(false, 'Got exception: ' + e);
+		done();
+	});
+
+});
+
+QUnit.test( "retrieveRuleSet: can't see protected properties", function(assert){
+
+	const ruleset_filename = 'test';
+
+	const config = {
+		query: (text, values) => {
+			if(text.startsWith('SELECT')) {
+				//the get current row test
+				return new Promise((resolve) => {
+					resolve({
+						rows: [
+							{
+								id: 0,
+								version: 0,
+								ruleset_id: ruleset_filename,
+								rules: {
+									import: {
+										filename: 'S3Import',
+										config: {
+											accessKey: '12345'
+										}
+									}
+								},
+								owner_user: null,
+								owner_group: 'test',
+								update_time: null,
+								name: null,
+								deleted: false
+							}
+						]
+					})
+				});
+
+			} else {
+
+				return new Promise((resolve, reject) => {
+					reject('not expected');
+				});
+			}
+		}
+	};
+
+	const done = assert.async();
+	const data = DataDb(config, true);
+
+	//ruleset_id, rulesetOverrideFile, ruleLoader, version, dbId, group, admin
+	data.retrieveRuleset(ruleset_filename, undefined, ruleLoader, undefined, undefined, undefined, undefined).then((ruleset) => {
+		assert.ok(ruleset, "Expect to have a ruleset");
+		assert.equal(ruleset.canedit, false, "Expect not to be able to edit");
+		assert.equal(ruleset.import.config.accessKey, '********', 'Private config should be blanked out');
+		done();
+	}, (e) => {
+		assert.ok(false, 'Got reject: ' + e);
+		done();
+	}).catch((e) => {
+		assert.ok(false, 'Got exception: ' + e);
+		done();
+	});
+
+});
+
+QUnit.test( "retrieveRuleSet: can see protected properties", function(assert){
+
+	const ruleset_filename = 'test';
+
+	const config = {
+		query: (text, values) => {
+			if(text.startsWith('SELECT')) {
+				//the get current row test
+				return new Promise((resolve) => {
+					resolve({
+						rows: [
+							{
+								id: 0,
+								version: 0,
+								ruleset_id: ruleset_filename,
+								rules: {
+									import: {
+										filename: 'S3Import',
+										config: {
+											accessKey: '12345'
+										}
+									}
+								},
+								owner_user: null,
+								owner_group: 'test',
+								update_time: null,
+								name: null,
+								deleted: false
+							}
+						]
+					})
+				});
+
+			} else {
+
+				return new Promise((resolve, reject) => {
+					reject('not expected');
+				});
+			}
+		}
+	};
+
+	const done = assert.async();
+	const data = DataDb(config, true);
+
+	//ruleset_id, rulesetOverrideFile, ruleLoader, version, dbId, group, admin
+	data.retrieveRuleset(ruleset_filename, undefined, ruleLoader, undefined, undefined, 'test', undefined).then((ruleset) => {
+		assert.ok(ruleset, "Expect to have a ruleset");
+		assert.equal(ruleset.canedit, true, "Expect to be able to edit");
+		assert.equal(ruleset.import.config.accessKey, '12345', 'Private config should be visible');
+		done();
+	}, (e) => {
+		assert.ok(false, 'Got reject: ' + e);
+		done();
+	}).catch((e) => {
+		assert.ok(false, 'Got exception: ' + e);
+		done();
+	});
+
+});
+
+QUnit.module("");

--- a/src/validator/validator.js
+++ b/src/validator/validator.js
@@ -99,14 +99,15 @@ class Validator {
 			this.runId = runId;
 			console.log("runId:" + runId);
 
-			this.data.retrieveRuleset(this.config.ruleset, this.config.rulesetOverride, this.ruleLoader)
+			this.data.retrieveRuleset(this.config.ruleset, this.config.rulesetOverride,
+				this.ruleLoader, undefined, undefined, undefined, true)
 				.then((ruleset) => {
 
 					if(!ruleset){
 						throw new Error("No Ruleset found for: " + this.config.ruleset);
 					}
 
-					ruleset.resolve(this.ruleLoader).then(() => {
+					ruleset.resolve(this.ruleLoader, undefined, true).then(() => {
 						this.processRuleset(ruleset, outputFile, inputEncoding, inputFile, inputDisplayName);
 					});
 

--- a/startPluto.sh
+++ b/startPluto.sh
@@ -24,3 +24,7 @@ docker stop pluto_nginx
 docker rm pluto_nginx
 
 docker run -v $PWD/test_nginx.conf:/etc/nginx/nginx.conf:ro -p 8001:8001 -p 8002:8002 -p 8003:8003 -p 8004:8004 --net=plutonet --name pluto_nginx -d nginx:stable-alpine
+
+docker stop pluto_s3server
+
+docker run -p 8000:8000 --net=plutonet --name pluto_s3server -d scality/s3server

--- a/test_config/rulesets/rules.json
+++ b/test_config/rulesets/rules.json
@@ -30,6 +30,36 @@
       "config": {
         "base": "/opt/PLUTO/config/tmp"
       }
+    },
+    {
+      "rule_id": "pluto_s3_source",
+      "type": "source",
+      "description": "Simulated S3",
+      "base": "S3Import",
+      "group": "sample",
+      "config": {
+        "accessKey": "verySecretKey1",
+        "endpoint": "localhost:8000",
+        "sslEnabled": false,
+        "bucket":"test",
+        "forcePathStyle":true,
+        "accessId":"accessKey1"
+      }
+    },
+    {
+      "rule_id": "pluto_s3_target",
+      "type": "target",
+      "description": "Simulated S3",
+      "base": "S3Export",
+      "group": "sample",
+      "config": {
+        "accessKey": "verySecretKey1",
+        "endpoint": "localhost:8000",
+        "sslEnabled": false,
+        "bucket":"testoutput",
+        "forcePathStyle":true,
+        "accessId":"accessKey1"
+      }
     }
   ]
 }


### PR DESCRIPTION
Added access control to fields on rules, importers, exporters, etc. by setting private: true on the config properties for that field.  If set, and the requesting user doesn't have edit rights, then those fields are blanked out (8 stars for strings) or removed from the object (non-strings).

The validator now has admin rights to pull data.