### PR TITLE
duplicating required rules

### DIFF
--- a/src/client/app/components/add-ruleset.js
+++ b/src/client/app/components/add-ruleset.js
@@ -103,6 +103,10 @@ export default Ember.Component.extend({
 			} else {
 				ruleset = ruleset.toJSON();
 
+				ruleset.rules = ruleset.rules.filter((val)=>{
+					return !val.injected;
+				});
+
 				ruleset.name = 'Copy of ' + ruleset.name;
 			}
 


### PR DESCRIPTION
If you clone a ruleset with required rules it will copy all the existing rules and then add more required rules on top, thus duplicating them. This will strip old required rules out of the clone before copy